### PR TITLE
[Performance] Parallel document iterators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamapun"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2018"
 authors = ["Deyan Ginev <deyan.ginev@gmail.com>", "Jan Frederik Schaefer <j.schaefer@jacobs-university.de>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ gnuplot = "0.0.21"
 unidecode = "0.2"
 rust-crypto = "0.2"
 lazy_static = "0.1"
-libxml = {version = "0.2.11", path = "../rust-libxml"}
+libxml = "0.2.11"
 tar = "0.4"
 rayon = "1.0"
 jwalk = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,7 @@ gnuplot = "0.0.21"
 unidecode = "0.2"
 rust-crypto = "0.2"
 lazy_static = "0.1"
-libxml = "0.2.9"
+libxml = {version = "0.2.11", path = "../rust-libxml"}
 tar = "0.4"
+rayon = "1.0"
+jwalk = "0.3"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The **llamapun** library hosts common _language and mathematics processing_ algo
 [![Build Status](https://travis-ci.org/KWARC/llamapun.svg?branch=master)](https://travis-ci.org/KWARC/llamapun)
 [![API Documentation](https://img.shields.io/badge/docs-API-blue.svg)](http://kwarc.github.io/llamapun/llamapun/index.html)
 [![license](http://img.shields.io/badge/license-GPLv3-blue.svg)](https://raw.githubusercontent.com/KWARC/llamapun/master/LICENSE)
-![version](https://img.shields.io/badge/version-0.2.3-orange.svg)
+![version](https://img.shields.io/badge/version-0.3.0-orange.svg)
 ---
 At its core, **llamapun** is a [Rust](http://rust-lang.org/) implementation that aims at minimal footprint and optimal runtime, in order to safely scale to corpora of millions of documents and tens of billions ot tokens.
 

--- a/examples/corpus_mathml_stats.rs
+++ b/examples/corpus_mathml_stats.rs
@@ -27,7 +27,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::{BufWriter, Error};
 
-use libxml::tree::Node;
+use libxml::readonly::RoNode;
 use llamapun::data::Corpus;
 
 static BUFFER_CAPACITY: usize = 10_485_760;
@@ -75,7 +75,7 @@ pub fn main() -> Result<(), Error> {
   for document in corpus.iter() {
     // Recursively descend through the math nodes and increment the frequencies of occurrence
     for math in document.get_math_nodes() {
-      dfs_record(&math, &open_ended, &mut catalog);
+      dfs_record(math, &open_ended, &mut catalog);
     }
 
     // Increment document counter, bokkeep
@@ -107,7 +107,7 @@ pub fn main() -> Result<(), Error> {
   node_statistics_writer.flush()
 }
 
-fn dfs_record(node: &Node, open_ended: &HashSet<&str>, catalog: &mut HashMap<String, u64>) {
+fn dfs_record(node: RoNode, open_ended: &HashSet<&str>, catalog: &mut HashMap<String, u64>) {
   if node.is_text_node() {
     return; // Skip text nodes.
   }
@@ -136,11 +136,11 @@ fn dfs_record(node: &Node, open_ended: &HashSet<&str>, catalog: &mut HashMap<Str
 
   // Recurse into all children (DFS)
   if let Some(child) = node.get_first_child() {
-    dfs_record(&child, open_ended, catalog);
+    dfs_record(child, open_ended, catalog);
     let mut child_node = child;
 
     while let Some(child) = child_node.get_next_sibling() {
-      dfs_record(&child, open_ended, catalog);
+      dfs_record(child, open_ended, catalog);
       child_node = child;
     }
   }

--- a/examples/corpus_node_model.rs
+++ b/examples/corpus_node_model.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
-use std::io::{Error, BufWriter};
+use std::io::{BufWriter, Error};
 
 use libxml::tree::Node;
 use llamapun::data::Corpus;
@@ -20,7 +20,6 @@ use llamapun::data::Corpus;
 static SPACE: &'static [u8] = b" ";
 static NEWLINE: &'static [u8] = b"\n";
 static BUFFER_CAPACITY: usize = 10_485_760;
-
 
 pub fn main() -> Result<(), Error> {
   let start = time::get_time();
@@ -75,10 +74,10 @@ pub fn main() -> Result<(), Error> {
   total_counts_vec.sort_by(|a, b| b.1.cmp(a.1));
 
   for (key, val) in total_counts_vec {
-    node_statistics_writer.write(key.as_bytes())?;
-    node_statistics_writer.write(SPACE)?;
-    node_statistics_writer.write(val.to_string().as_bytes())?;
-    node_statistics_writer.write(NEWLINE)?;
+    node_statistics_writer.write_all(key.as_bytes())?;
+    node_statistics_writer.write_all(SPACE)?;
+    node_statistics_writer.write_all(val.to_string().as_bytes())?;
+    node_statistics_writer.write_all(NEWLINE)?;
   }
   // Close the writer
   node_statistics_writer.flush()
@@ -89,7 +88,8 @@ fn dfs_record<W>(
   total_counts: &mut HashMap<String, u32>,
   node_model_writer: &mut BufWriter<W>,
 ) -> Result<(), Error>
-  where W: std::io::Write,
+where
+  W: std::io::Write,
 {
   if node.is_text_node() {
     return Ok(()); // Skip text nodes.
@@ -113,8 +113,8 @@ fn dfs_record<W>(
     *node_count += 1;
   }
   // Write the model_token of the current node into the buffer
-  node_model_writer.write(model_token.as_bytes())?;
-  node_model_writer.write(SPACE)?;
+  node_model_writer.write_all(model_token.as_bytes())?;
+  node_model_writer.write_all(SPACE)?;
 
   // Recurse into all children (DFS), except for math and tables
   if (node_name != "math") && (node_name != "table") {

--- a/examples/corpus_node_model.rs
+++ b/examples/corpus_node_model.rs
@@ -3,21 +3,16 @@
 //
 
 //! Given a `CorTeX` corpus of HTML5 documents, extract a node model as a single file
-
-extern crate libxml;
-extern crate llamapun;
-extern crate time;
-
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{BufWriter, Error};
+use std::sync::{Arc, Mutex};
 
-use libxml::tree::Node;
-use llamapun::data::Corpus;
+use libxml::readonly::RoNode;
+use llamapun::parallel_data::Corpus;
 
-static SPACE: &'static [u8] = b" ";
 static NEWLINE: &'static [u8] = b"\n";
 static BUFFER_CAPACITY: usize = 10_485_760;
 
@@ -39,43 +34,43 @@ pub fn main() -> Result<(), Error> {
     None => "node_statistics.txt".to_string(),
   };
 
-  let node_model_file = File::create(node_model_filepath)?;
-  let mut node_model_writer = BufWriter::with_capacity(BUFFER_CAPACITY, node_model_file);
-
   let node_statistics_file = File::create(node_statistics_filepath)?;
-  let mut node_statistics_writer = BufWriter::with_capacity(BUFFER_CAPACITY, node_statistics_file);
+  let node_model_file = File::create(node_model_filepath)?;
+  let node_model_writer = Arc::new(Mutex::new(BufWriter::with_capacity(
+    BUFFER_CAPACITY,
+    node_model_file,
+  )));
 
-  let mut total_counts = HashMap::new();
   let mut corpus = Corpus::new(corpus_path);
-  for document in corpus.iter() {
+  let total_counts = corpus.catalog_with_parallel_walk(|document| {
     // Recursively descend the dom DFS and record to the token model
-    if let Some(root) = document.dom.get_root_element() {
-      dfs_record(&root, &mut total_counts, &mut node_model_writer)?;
+    let mut total_counts = HashMap::new();
+    if let Some(root) = document.dom.get_root_readonly() {
+      let thread_writer = node_model_writer.clone();
+      let node_model =
+        dfs_record(root, &mut total_counts).expect("dfs_record should not encounter any issues.");
+      let mut writer_lock = thread_writer.lock().unwrap();
+      writer_lock
+        .write_all(&node_model)
+        .expect("buffer writes should not encounter any issues");
     }
+    total_counts
+  });
 
-    // Increment document counter, bokkeep
-    let document_count = total_counts
-      .entry("document_count".to_string())
-      .or_insert(0);
-    *document_count += 1;
-    if *document_count % 1000 == 0 {
-      println!("-- processed documents: {:?}", document_count);
-    }
-  }
-
-  node_model_writer.flush()?;
+  node_model_writer.lock().unwrap().flush()?;
 
   let end = time::get_time();
   let duration_sec = (end - start).num_milliseconds() / 1000;
   println!("---");
   println!("Node model finished in {:?}s", duration_sec);
 
-  let mut total_counts_vec: Vec<(&String, &u32)> = total_counts.iter().collect();
+  let mut total_counts_vec: Vec<(&String, &u64)> = total_counts.iter().collect();
   total_counts_vec.sort_by(|a, b| b.1.cmp(a.1));
 
+  let mut node_statistics_writer = BufWriter::with_capacity(BUFFER_CAPACITY, node_statistics_file);
   for (key, val) in total_counts_vec {
     node_statistics_writer.write_all(key.as_bytes())?;
-    node_statistics_writer.write_all(SPACE)?;
+    node_statistics_writer.write_all(b" ")?;
     node_statistics_writer.write_all(val.to_string().as_bytes())?;
     node_statistics_writer.write_all(NEWLINE)?;
   }
@@ -83,16 +78,10 @@ pub fn main() -> Result<(), Error> {
   node_statistics_writer.flush()
 }
 
-fn dfs_record<W>(
-  node: &Node,
-  total_counts: &mut HashMap<String, u32>,
-  node_model_writer: &mut BufWriter<W>,
-) -> Result<(), Error>
-where
-  W: std::io::Write,
-{
+fn dfs_record(node: RoNode, total_counts: &mut HashMap<String, u64>) -> Result<Vec<u8>, Error> {
+  let mut subtree_model = Vec::new();
   if node.is_text_node() {
-    return Ok(()); // Skip text nodes.
+    return Ok(subtree_model); // Skip text nodes.
   }
 
   let node_name = node.get_name();
@@ -104,7 +93,7 @@ where
     if class_model_token.is_empty() {
       continue;
     }
-    model_token.push_str("_");
+    model_token.push('_');
     model_token.push_str(class_model_token);
   }
   // Increment counter for this type of node
@@ -113,20 +102,20 @@ where
     *node_count += 1;
   }
   // Write the model_token of the current node into the buffer
-  node_model_writer.write_all(model_token.as_bytes())?;
-  node_model_writer.write_all(SPACE)?;
+  subtree_model.extend(model_token.as_bytes());
+  subtree_model.push(b' ');
 
   // Recurse into all children (DFS), except for math and tables
   if (node_name != "math") && (node_name != "table") {
     if let Some(child) = node.get_first_child() {
-      dfs_record(&child, total_counts, node_model_writer)?;
-      let mut child_node = child;
+      subtree_model.extend(dfs_record(child, total_counts)?);
 
-      while let Some(child) = child_node.get_next_sibling() {
-        dfs_record(&child, total_counts, node_model_writer)?;
-        child_node = child;
+      let mut child_node = child;
+      while let Some(sibling) = child_node.get_next_sibling() {
+        subtree_model.extend(dfs_record(sibling, total_counts)?);
+        child_node = sibling;
       }
     }
   }
-  Ok(())
+  Ok(subtree_model)
 }

--- a/examples/pre_ref_words.rs
+++ b/examples/pre_ref_words.rs
@@ -86,13 +86,13 @@ pub fn main() -> Result<(), Error> {
   catalog_vec.sort_by(|a, b| b.1.cmp(a.1));
 
   let mut node_statistics_writer = BufWriter::with_capacity(BUFFER_CAPACITY, node_statistics_file);
-  node_statistics_writer.write(b"word, frequency\n")?;
+  node_statistics_writer.write_all(b"word, frequency\n")?;
 
   for (key, val) in catalog_vec {
-    node_statistics_writer.write(key.as_bytes())?;
-    node_statistics_writer.write(b", ")?;
-    node_statistics_writer.write(val.to_string().as_bytes())?;
-    node_statistics_writer.write(b"\n")?;
+    node_statistics_writer.write_all(key.as_bytes())?;
+    node_statistics_writer.write_all(b", ")?;
+    node_statistics_writer.write_all(val.to_string().as_bytes())?;
+    node_statistics_writer.write_all(b"\n")?;
   }
   // Close the writer
   node_statistics_writer.flush()

--- a/src/dnm/mod.rs
+++ b/src/dnm/mod.rs
@@ -224,7 +224,7 @@ impl DNM {
     if self.parameters.support_back_mapping {
       assert_eq!(string.chars().count(), offsets.len());
       for offset in offsets {
-        self.back_map.push((node.clone(), offset));
+        self.back_map.push((node, offset));
       }
     }
 

--- a/src/dnm/node.rs
+++ b/src/dnm/node.rs
@@ -1,16 +1,18 @@
-use libxml::tree::Node;
+use libxml::readonly::RoNode;
 use libxml::xpath::Context;
 
 /// Map math nodes to their lexemes
-pub fn lexematize_math(node: &Node, context: &mut Context) -> String {
+pub fn lexematize_math(node: RoNode, context: &mut Context) -> String {
   // We are going to descend down an assumed equation/formula/eqnarray, grabbing any x-llamapun
   // encoded lexemes we can find
 
   let annotations = context
-    .findnodes(
+    .node_evaluate_readonly(
       ".//*[local-name()='annotation' and @encoding='application/x-llamapun']",
-      Some(node),
-    ).unwrap();
+      node,
+    )
+    .unwrap()
+    .get_readonly_nodes_as_vec();
 
   let lexemes: String = annotations
     .iter()
@@ -28,11 +30,14 @@ pub fn lexematize_math(node: &Node, context: &mut Context) -> String {
                 ':' | '-' => '_',
                 '\n' => ' ',
                 _ => c,
-              }).collect()
+              })
+              .collect()
           }
-        }).collect::<Vec<String>>()
+        })
+        .collect::<Vec<String>>()
         .join(" ")
-    }).collect::<Vec<String>>()
+    })
+    .collect::<Vec<String>>()
     .join(" ");
   if !lexemes.is_empty() {
     lexemes

--- a/src/dnm/parameters.rs
+++ b/src/dnm/parameters.rs
@@ -1,10 +1,10 @@
 //! The `dnm::parameters` submodule provides data structures for customizing
 //! and configuring a DNM's construction and use
 
-use libxml::tree::*;
-use std::fmt;
+use libxml::readonly::RoNode;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::fmt;
+use std::sync::Arc;
 
 /// Some temporary data for the parser
 #[derive(Debug)]
@@ -32,7 +32,7 @@ pub enum SpecialTagsOption {
   /// Normalize tag, replacing it by some token
   Normalize(String),
   /// Normalize tag, obtain replacement string by function call
-  FunctionNormalize(Rc<fn(&Node) -> String>),
+  FunctionNormalize(Arc<fn(RoNode) -> String>),
   /// Skip tag
   Skip,
 }
@@ -40,14 +40,14 @@ pub enum SpecialTagsOption {
 impl fmt::Debug for SpecialTagsOption {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     use SpecialTagsOption::*;
-    write!(f,"SpecialTagsOption {{")?;
+    write!(f, "SpecialTagsOption {{")?;
     match self {
       Enter => write!(f, "Enter")?,
       Skip => write!(f, "Skip")?,
       Normalize(v) => write!(f, "Normalize({})", v)?,
-      FunctionNormalize(_) => write!(f, "FunctionNormalize")?
+      FunctionNormalize(_) => write!(f, "FunctionNormalize")?,
     };
-    write!(f,"}}")
+    write!(f, "}}")
   }
 }
 

--- a/src/dnm/range.rs
+++ b/src/dnm/range.rs
@@ -190,9 +190,9 @@ impl<'dnmrange> DNMRange<'dnmrange> {
           );
         } else {
           let act = if is_end {
-            get_next_sibling(root_node, node).unwrap_or_else(|| node.clone())
+            get_next_sibling(root_node, node).unwrap_or(node)
           } else {
-            node.clone()
+            node
           };
           let parent = act.get_parent().unwrap();
           let base = DNMRange::serialize_node(root_node, parent, false /* don't take next */);
@@ -261,7 +261,7 @@ impl<'dnmrange> DNMRange<'dnmrange> {
       let node_str = &string[13..comma];
       let node_set = xpath_context.evaluate(node_str).unwrap();
       assert_eq!(node_set.get_number_of_nodes(), 1);
-      let node = node_set.get_readonly_nodes_as_vec()[0].clone();
+      let node = node_set.get_readonly_nodes_as_vec()[0];
       match dnm.get_range_of_node(node) {
         Ok(range) => {
           let mut pos = range.start;
@@ -279,7 +279,7 @@ impl<'dnmrange> DNMRange<'dnmrange> {
         .evaluate(node_str)
         .unwrap_or_else(|_| panic!("DNMRange::deserialize: Malformed XPath: '{}'", &node_str));
       assert_eq!(node_set.get_number_of_nodes(), 1);
-      let node = node_set.get_readonly_nodes_as_vec()[0].clone();
+      let node = node_set.get_readonly_nodes_as_vec()[0];
       get_position_of_lowest_parent(node, dnm)
     }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod ams;
 pub mod data;
 pub mod dnm;
 pub mod ngrams;
+pub mod parallel_data;
 pub mod patterns;
 pub mod stopwords;
 pub mod tokenizer;

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -123,7 +123,7 @@ impl Corpus {
     F: Fn(Document) -> HashMap<String, u64> + Send + Sync,
   {
     ParWalkDir::new(self.path.clone())
-      .num_threads(dbg!(rayon::current_num_threads()))
+      .num_threads(rayon::current_num_threads())
       .skip_hidden(true)
       .sort(false)
       .into_iter()

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -154,16 +154,13 @@ impl Corpus {
         let document = Document::new(path, &self).unwrap();
         closure(document)
       })
-      .reduce(
-        || HashMap::new(),
-        |mut map1, map2| {
-          for (k, v) in map2 {
-            let entry = map1.entry(k).or_insert(0);
-            *entry += v;
-          }
-          map1
-        },
-      )
+      .reduce(HashMap::new, |mut map1, map2| {
+        for (k, v) in map2 {
+          let entry = map1.entry(k).or_insert(0);
+          *entry += v;
+        }
+        map1
+      })
   }
 }
 

--- a/src/patterns/matching.rs
+++ b/src/patterns/matching.rs
@@ -1,6 +1,6 @@
 //! The code for the actual matching
 
-use libxml::tree::*;
+use libxml::readonly::RoNode;
 
 use crate::patterns::rules::*;
 use crate::patterns::utils::*;
@@ -116,14 +116,14 @@ impl PhraseTree {
                 start_opt = Some(p);
               }
               end = p;
-            },
+            }
             Ok(t) => {
               if start_opt.is_none() {
                 start_opt = Some(t.start);
               }
               end = t.end;
               child_trees.push(t);
-            },
+            }
           }
         }
         let start = start_opt.unwrap_or_default();
@@ -133,7 +133,7 @@ impl PhraseTree {
           end,
           children: child_trees,
         })
-      },
+      }
     }
   }
 }
@@ -171,8 +171,7 @@ pub fn match_sentence<'t>(
   sentence: &Sentence,
   range: &'t DNMRange,
   rule: &str,
-) -> Result<Vec<Match<'t>>, String>
-{
+) -> Result<Vec<Match<'t>>, String> {
   /* if !range.dnm.parameters.support_back_mapping {
   return Err("DNM of sentence does not support back mapping".to_string());
   } */
@@ -213,8 +212,7 @@ fn match_seq<'t>(
   phrase_tree: &PhraseTree,
   range: &'t DNMRange,
   pos: usize,
-) -> InternalSeqMatch<'t>
-{
+) -> InternalSeqMatch<'t> {
   match *rule {
     SequencePattern::SeqRef(p) => match_seq(
       pf,
@@ -238,7 +236,7 @@ fn match_seq<'t>(
         end: pos + 1,
         matched: true,
       }
-    },
+    }
     SequencePattern::SeqOfSeq(ref patterns) => {
       let mut matches: Vec<Match> = Vec::new();
       let mut cur_pos = pos;
@@ -256,7 +254,7 @@ fn match_seq<'t>(
         end: cur_pos,
         matched: true,
       }
-    },
+    }
     SequencePattern::Phrase(phrase, ref match_type, ref start_condition, ref end_condition) => {
       let mut phrase_ends = get_phrase_matches(phrase_tree, pos, phrase);
       if match_type == &PhraseMatchType::Longest {
@@ -308,7 +306,7 @@ fn match_seq<'t>(
 
       // no phrase match satisfied all conditions:
       InternalSeqMatch::no_match()
-    },
+    }
     SequencePattern::Marked(ref pattern, ref marker) => {
       let m = match_seq(pf, pattern, sentence, phrase_tree, range, pos);
       if m.matched {
@@ -330,7 +328,7 @@ fn match_seq<'t>(
       } else {
         InternalSeqMatch::no_match()
       }
-    },
+    }
     SequencePattern::SeqOr(ref patterns, ref match_type) => {
       let mut matches: Vec<Match> = Vec::new();
       let mut matched = false;
@@ -346,19 +344,19 @@ fn match_seq<'t>(
                 longest = m.end;
               }
               break;
-            },
+            }
             SequenceMatchType::AtLeastOne | SequenceMatchType::Any => {
               if m.end > longest {
                 longest = m.end;
               }
               matches.extend_from_slice(&m._matches);
-            },
+            }
             SequenceMatchType::Longest => {
               if m.end > longest {
                 longest = m.end;
                 matches = m._matches;
               }
-            },
+            }
           }
         }
       }
@@ -372,7 +370,7 @@ fn match_seq<'t>(
           matched: true, // don't use `matched` (because SequenceMatchType::Any matches always)
         }
       }
-    },
+    }
   }
 }
 
@@ -381,8 +379,7 @@ fn match_word<'t>(
   rule: &WordPattern,
   word: &Word,
   range: &'t DNMRange,
-) -> InternalWordMatch<'t>
-{
+) -> InternalWordMatch<'t> {
   match *rule {
     WordPattern::WordRef(rule_pos) => match_word(pf, &pf.word_rules[rule_pos].pattern, word, range),
     WordPattern::WordOr(ref word_patterns) => {
@@ -393,7 +390,7 @@ fn match_word<'t>(
         }
       }
       InternalWordMatch::no_match()
-    },
+    }
     WordPattern::Word(ref word_str) => {
       if word_str == word.get_string() {
         InternalWordMatch {
@@ -403,14 +400,14 @@ fn match_word<'t>(
       } else {
         InternalWordMatch::no_match()
       }
-    },
+    }
     WordPattern::WordPos(ref pos_pattern, ref word_pattern) => {
       if match_pos(pf, pos_pattern, word.get_pos()) {
         match_word(pf, word_pattern, word, range)
       } else {
         InternalWordMatch::no_match()
       }
-    },
+    }
     WordPattern::MathWord(ref math_pattern) => {
       let node = range.dnm.back_map[range.start + word.get_offset_start()]
         .0
@@ -418,20 +415,20 @@ fn match_word<'t>(
       if node.get_name() != "math" {
         return InternalWordMatch::no_match();
       }
-      let children = fast_get_non_text_children(&node);
+      let children = fast_get_non_text_children(node);
       if children.is_empty() {
         return InternalWordMatch::no_match();
       }
 
       // TODO: Make the following code work in the general case!!!
       let m = if children[0].get_name() == "semantics" {
-        let c = fast_get_non_text_children(&children[0]);
+        let c = fast_get_non_text_children(children[0]);
         if c.is_empty() {
           return InternalWordMatch::no_match();
         }
-        match_math(pf, math_pattern, &c[0])
+        match_math(pf, math_pattern, c[0])
       } else {
-        match_math(pf, math_pattern, &children[0])
+        match_math(pf, math_pattern, children[0])
       };
       if m.matched {
         InternalWordMatch {
@@ -441,7 +438,7 @@ fn match_word<'t>(
       } else {
         InternalWordMatch::no_match()
       }
-    },
+    }
     WordPattern::AnyWord => InternalWordMatch {
       _matches: Vec::new(),
       matched: true,
@@ -453,7 +450,7 @@ fn match_word<'t>(
       } else {
         InternalWordMatch::no_match()
       }
-    },
+    }
     WordPattern::Marked(ref p, ref marker) => {
       let m = match_word(pf, p, word, range);
       if m.matched {
@@ -470,11 +467,11 @@ fn match_word<'t>(
       } else {
         InternalWordMatch::no_match()
       }
-    },
+    }
   }
 }
 
-fn match_math<'t>(pf: &PatternFile, rule: &MathPattern, node: &Node) -> InternalMathMatch<'t> {
+fn match_math<'t>(pf: &PatternFile, rule: &MathPattern, node: RoNode) -> InternalMathMatch<'t> {
   match *rule {
     MathPattern::AnyMath => InternalMathMatch {
       _matches: Vec::new(),
@@ -487,7 +484,7 @@ fn match_math<'t>(pf: &PatternFile, rule: &MathPattern, node: &Node) -> Internal
         InternalMathMatch {
           _matches: vec![Match {
             marker: MarkerEnum::Math(MathMarker {
-              node: node.clone(),
+              node,
               marker: marker.clone(),
             }),
             sub_matches: m._matches,
@@ -497,7 +494,7 @@ fn match_math<'t>(pf: &PatternFile, rule: &MathPattern, node: &Node) -> Internal
       } else {
         InternalMathMatch::no_match()
       }
-    },
+    }
     MathPattern::MathOr(ref patterns) => {
       for pattern in patterns {
         let m = match_math(pf, pattern, node);
@@ -506,7 +503,7 @@ fn match_math<'t>(pf: &PatternFile, rule: &MathPattern, node: &Node) -> Internal
         }
       }
       InternalMathMatch::no_match()
-    },
+    }
     MathPattern::MathNode(ref name, ref mtext, ref children) => {
       // Here we will use that each MathPattern matches exactly one node for
       // optimization purposes
@@ -552,7 +549,7 @@ fn match_math<'t>(pf: &PatternFile, rule: &MathPattern, node: &Node) -> Internal
           let mut matches: Vec<Match> = Vec::new();
           let mut matched = true;
           for i in 0..child_rules.len() {
-            let m = match_math(pf, &child_rules[i], &c_nodes[start_pos + i]);
+            let m = match_math(pf, &child_rules[i], c_nodes[start_pos + i]);
             if m.matched {
               matches.extend_from_slice(&m._matches[..]);
             } else {
@@ -581,7 +578,7 @@ fn match_math<'t>(pf: &PatternFile, rule: &MathPattern, node: &Node) -> Internal
         _matches: Vec::new(),
         matched: true,
       } // no child matches required
-    },
+    }
     MathPattern::MathDescendant(ref pattern, ref match_type) => {
       let mut matches: Vec<Match> = Vec::new();
       let mut matched = false;
@@ -590,7 +587,7 @@ fn match_math<'t>(pf: &PatternFile, rule: &MathPattern, node: &Node) -> Internal
         matched = true;
         matches.extend_from_slice(&m._matches[..]);
       }
-      for child in &fast_get_non_text_children(node) {
+      for child in fast_get_non_text_children(node).into_iter() {
         if matched && match_type == &MathDescendantMatchType::First {
           return InternalMathMatch {
             _matches: matches,
@@ -612,7 +609,7 @@ fn match_math<'t>(pf: &PatternFile, rule: &MathPattern, node: &Node) -> Internal
       } else {
         InternalMathMatch::no_match()
       }
-    },
+    }
   }
 }
 

--- a/src/patterns/matching.rs
+++ b/src/patterns/matching.rs
@@ -277,11 +277,10 @@ fn match_seq<'t>(
           }
           matches.extend_from_slice(&m._matches[..]);
         }
-        if end_condition.is_some() {
+        if let Some(rule) = end_condition {
           let mut matched = false;
           for end_start_pos in pos..*end_pos {
-            let &ref rule = end_condition.as_ref().unwrap();
-            let m = match_seq(pf, rule, sentence, phrase_tree, range, end_start_pos);
+            let m = match_seq(pf, &rule, sentence, phrase_tree, range, end_start_pos);
             if !m.matched {
               continue;
             }
@@ -409,9 +408,7 @@ fn match_word<'t>(
       }
     }
     WordPattern::MathWord(ref math_pattern) => {
-      let node = range.dnm.back_map[range.start + word.get_offset_start()]
-        .0
-        .clone();
+      let node = range.dnm.back_map[range.start + word.get_offset_start()].0;
       if node.get_name() != "math" {
         return InternalWordMatch::no_match();
       }

--- a/src/patterns/utils.rs
+++ b/src/patterns/utils.rs
@@ -72,7 +72,7 @@ pub fn fast_get_non_text_children(node: RoNode) -> Vec<RoNode> {
     }
     let cur_ = cur.unwrap();
     if !cur_.is_text_node() && !is_comment_node(cur_) {
-      children.push(cur_.clone());
+      children.push(cur_);
     }
     cur = cur_.get_next_sibling();
   }

--- a/tests/dnm_c14n_test.rs
+++ b/tests/dnm_c14n_test.rs
@@ -12,8 +12,8 @@ fn test_c14n_basic() {
   let parser = Parser::default();
   let doc = parser.parse_file("tests/resources/file01.xml").unwrap();
 
-  let root = doc.get_root_element().unwrap();
-  let dnm = DNM::new(&root, DNMParameters::default());
+  let root = doc.get_root_readonly().unwrap();
+  let dnm = DNM::new(root, DNMParameters::default());
   let c14n = dnm.to_c14n_basic();
   assert!(!c14n.is_empty());
 }
@@ -25,8 +25,8 @@ fn test_c14n_basic_full() {
     .parse_file("tests/resources/1311.0066.xhtml")
     .unwrap();
 
-  let root = doc.get_root_element().unwrap();
-  let dnm = DNM::new(&root, DNMParameters::default());
+  let root = doc.get_root_readonly().unwrap();
+  let dnm = DNM::new(root, DNMParameters::default());
   let c14n = dnm.to_c14n_basic();
   assert!(!c14n.is_empty());
 }
@@ -36,12 +36,12 @@ fn test_c14n_math_hash() {
   let parser = Parser::default();
   let doc = parser.parse_file("tests/resources/0903.1000.html").unwrap();
 
-  let root = doc.get_root_element().unwrap();
-  let dnm = DNM::new(&root, DNMParameters::default());
+  let root = doc.get_root_readonly().unwrap();
+  let dnm = DNM::new(root, DNMParameters::default());
 
   let xpath_context = Context::new(&doc).unwrap();
   let formulas = match xpath_context.evaluate("//*[contains(@class,'ltx_Math')]") {
-    Ok(xpath_result) => xpath_result.get_nodes_as_vec(),
+    Ok(xpath_result) => xpath_result.get_readonly_nodes_as_vec(),
     _ => Vec::new(),
   };
 
@@ -49,13 +49,13 @@ fn test_c14n_math_hash() {
   let mut formula_hashes = HashSet::new();
 
   for formula in formulas {
-    let canonical_formula = dnm.node_c14n_basic(&formula);
+    let canonical_formula = dnm.node_c14n_basic(formula);
     assert!(!canonical_formula.is_empty());
     // println!("Formula: \n{}", canonical_formula);
     // insert formula in hash
     formula_c14ns.insert(canonical_formula);
     // compute md5 hash of formula, and insert it in hash
-    let formula_hash = dnm.node_hash_basic(&formula);
+    let formula_hash = dnm.node_hash_basic(formula);
     // println!("MD5: {}", formula_hash);
     formula_hashes.insert(formula_hash);
   }

--- a/tests/dnm_test.rs
+++ b/tests/dnm_test.rs
@@ -20,9 +20,9 @@ fn test_plaintext_simple() {
     "a".to_string(),
     SpecialTagsOption::Normalize("[link]".to_string()),
   );
-  let root = doc.get_root_element().unwrap();
+  let root = doc.get_root_readonly().unwrap();
   let dnm = DNM::new(
-    &root,
+    root,
     DNMParameters {
       special_tag_name_options: options,
       normalize_white_spaces: true,
@@ -39,15 +39,15 @@ fn test_plaintext_simple() {
 fn test_non_normalized_unicode() {
   let parser = Parser::default();
   let doc = parser.parse_file("tests/resources/file05.xml").unwrap();
-  let root = doc.get_root_element().unwrap();
+  let root = doc.get_root_readonly().unwrap();
   let dnm = DNM::new(
-    &root,
+    root,
     DNMParameters {
       normalize_unicode: false,
       ..DNMParameters::default()
     },
   );
-  let entire_range = dnm.get_range_of_node(&root).unwrap();
+  let entire_range = dnm.get_range_of_node(root).unwrap();
   let trimmed = entire_range.trim();
   let unicode = trimmed.get_subrange(0, 7);
   assert_eq!(unicode.get_plaintext(), "Unicöde");
@@ -72,15 +72,15 @@ fn test_xml_node_to_plaintext() {
     "a".to_string(),
     SpecialTagsOption::Normalize("[link]".to_string()),
   );
-  let root = doc.get_root_element().unwrap();
+  let root = doc.get_root_readonly().unwrap();
   let dnm = DNM::new(
-    &root,
+    root,
     DNMParameters {
       special_tag_name_options: options,
       ..Default::default()
     },
   );
-  let mut node = doc.get_root_element().unwrap();
+  let mut node = doc.get_root_readonly().unwrap();
   match node.get_first_child() {
     Some(n) => node = n,
     None => assert!(false), //DOM generation failed
@@ -100,7 +100,7 @@ fn test_xml_node_to_plaintext() {
   }
   //Node content should have been processed
   assert_eq!(
-    dnm.get_range_of_node(&node).unwrap().get_plaintext(),
+    dnm.get_range_of_node(node).unwrap().get_plaintext(),
     "Title"
   );
   while node.get_name() != "h2" {
@@ -110,7 +110,7 @@ fn test_xml_node_to_plaintext() {
     }
   }
   //node was skipped in dnm generation
-  assert_eq!(dnm.get_range_of_node(&node).unwrap().get_plaintext(), "");
+  assert_eq!(dnm.get_range_of_node(node).unwrap().get_plaintext(), "");
   while node.get_name() != "a" {
     match node.get_next_sibling() {
       Some(n) => node = n,
@@ -119,7 +119,7 @@ fn test_xml_node_to_plaintext() {
   }
   //node content should have been replaced by "[link]"
   assert_eq!(
-    dnm.get_range_of_node(&node).unwrap().get_plaintext().trim(),
+    dnm.get_range_of_node(node).unwrap().get_plaintext().trim(),
     "[link]"
   );
 }
@@ -128,14 +128,14 @@ fn test_xml_node_to_plaintext() {
 fn test_back_mapping_simple() {
   let parser = Parser::default();
   let doc = parser.parse_file("tests/resources/file01.xml").unwrap();
-  let root = doc.get_root_element().unwrap();
+  let root = doc.get_root_readonly().unwrap();
   let mut options: HashMap<String, SpecialTagsOption> = HashMap::new();
   options.insert(
     "a".to_string(),
     SpecialTagsOption::Normalize("[link]".to_string()),
   );
   let dnm = DNM::new(
-    &root,
+    root,
     DNMParameters {
       special_tag_name_options: options,
       normalize_white_spaces: true,
@@ -188,9 +188,9 @@ fn test_plaintext_normalized_class_names() {
     "normalized".to_string(),
     SpecialTagsOption::Normalize("[NORMALIZED]".to_string()),
   );
-  let root = doc.get_root_element().unwrap();
+  let root = doc.get_root_readonly().unwrap();
   let dnm = DNM::new(
-    &root,
+    root,
     DNMParameters {
       special_tag_class_options: options,
       normalize_white_spaces: true,
@@ -204,16 +204,16 @@ fn test_plaintext_normalized_class_names() {
 fn test_unicode_normalization() {
   let parser = Parser::default();
   let doc = parser.parse_file("tests/resources/file03.xml").unwrap();
-  let root = doc.get_root_element().unwrap();
+  let root = doc.get_root_readonly().unwrap();
   let dnm = DNM::new(
-    &root,
+    root,
     DNMParameters {
       normalize_unicode: true,
       ..DNMParameters::default()
     },
   );
-  let node = doc.get_root_element().unwrap();
-  let dnmrange = dnm.get_range_of_node(&node).unwrap();
+  let node = doc.get_root_readonly().unwrap();
+  let dnmrange = dnm.get_range_of_node(node).unwrap();
   assert_eq!(dnmrange.get_plaintext().trim(), "At houEUR...");
 }
 
@@ -221,17 +221,17 @@ fn test_unicode_normalization() {
 fn test_morpha_stemming() {
   let parser = Parser::default();
   let doc = parser.parse_file("tests/resources/file04.xml").unwrap();
-  let root = doc.get_root_element().unwrap();
+  let root = doc.get_root_readonly().unwrap();
   let dnm = DNM::new(
-    &root,
+    root,
     DNMParameters {
       stem_words_once: true,
       support_back_mapping: false,
       ..Default::default()
     },
   );
-  let node = doc.get_root_element().unwrap();
-  let dnmrange = dnm.get_range_of_node(&node).unwrap().trim();
+  let node = doc.get_root_readonly().unwrap();
+  let dnmrange = dnm.get_range_of_node(node).unwrap().trim();
 
   assert_eq!(
     dnmrange.get_plaintext().trim(),

--- a/tests/parallel_test.rs
+++ b/tests/parallel_test.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+use llamapun::parallel_data::{Corpus};
+
+#[test]
+fn can_iterate_corpus() {
+  let mut corpus = Corpus::new("tests".to_string());
+  let catalog = corpus.catalog_with_parallel_walk(|document| {
+    let mut thread_count = HashMap::new();
+    thread_count.insert(String::from("doc_count"), 1);
+    let mut word_count = 0;
+    for mut paragraph in document.paragraph_iter() {
+      for mut sentence in paragraph.iter() {
+        for word in sentence.simple_iter() {
+          word_count += 1;
+          assert!(!word.range.is_empty());
+        }
+      }
+    }
+    thread_count.insert(String::from("word_count"), word_count);
+    thread_count
+  });
+
+  let word_count = catalog.get("word_count").unwrap_or(&0);
+  let doc_count = catalog.get("doc_count").unwrap_or(&0);
+  println!("Words iterated on: {:?}", word_count);
+  assert_eq!(*doc_count, 2, "expected 2 documents, found {:?}", doc_count);
+  assert!(
+    *word_count > 8400,
+    "expected more than 8400 words, found {:?}",
+    word_count
+  );
+}

--- a/tests/tokenization_test.rs
+++ b/tests/tokenization_test.rs
@@ -4,7 +4,6 @@ use libxml::xpath::*;
 use llamapun::dnm::{DNMParameters, DNMRange, DNM};
 use llamapun::tokenizer::*;
 use regex::Regex;
-use std::collections::HashMap;
 
 #[test]
 /// Test sentence tokenization of a simple document

--- a/tests/tokenization_test.rs
+++ b/tests/tokenization_test.rs
@@ -1,13 +1,10 @@
-extern crate libxml;
-extern crate llamapun;
-extern crate regex;
-
 use libxml::parser::Parser;
 use libxml::tree::*;
 use libxml::xpath::*;
 use llamapun::dnm::{DNMParameters, DNMRange, DNM};
 use llamapun::tokenizer::*;
 use regex::Regex;
+use std::collections::HashMap;
 
 #[test]
 /// Test sentence tokenization of a simple document
@@ -94,8 +91,8 @@ fn test_each_paragraph<'a>(doc: &'a Document, expected: &[Vec<&'a str>]) {
     .unwrap();
 
   let mut expected_iter = expected.iter();
-  for para in para_xpath_result.get_nodes_as_vec() {
-    let dnm = DNM::new(&para, DNMParameters::llamapun_normalization());
+  for para in para_xpath_result.get_readonly_nodes_as_vec() {
+    let dnm = DNM::new(para, DNMParameters::llamapun_normalization());
 
     let paragraph_expected = expected_iter.next().unwrap();
     let expected_paragraph = multispace.replace_all(paragraph_expected[0], "_");


### PR DESCRIPTION
Fixes #28 

Technical aspects I'd like to improve:
 * Can `parallel_data` be just an extension over `data` without having to copy-paste boilerplate?
 * Can the parallel walk be generalized further, rather than the very specific current
```rust
corpus.catalog_with_parallel_walk(|document| {
 /// ...
}
```
  * Is the internal multi-threading (over XPath-returned paragraphs) really reliably faster than using a single thread? Does the `.reduce()` calls add significant overhead when merging HashMaps?
