### PR TITLE
Paragraph dataset, first official release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ libxml = "0.2.11"
 tar = "0.4"
 rayon = "1.0"
 jwalk = "0.4"
+whatlang = "0.7.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/examples/corpus_ams_para_model.rs
+++ b/examples/corpus_ams_para_model.rs
@@ -10,7 +10,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use libxml::xpath::Context;
 use tar::{Builder, Header};
-use whatlang::{detect, Lang, Script};
 
 use llamapun::ams;
 use llamapun::ams::{AmsEnv, StructuralEnv};
@@ -116,20 +115,8 @@ pub fn main() -> Result<(), Error> {
         continue 'paragraphs;
       }
       // Before we go into tokenization, ensure this is an English sentence on the math-normalized plain text.
-      let detectable_with_spaces = paragraph.dnm.plaintext.replace("MathFormula", "");
-      let detectable = detectable_with_spaces.trim();
-      if let Some(info) = detect(&detectable) {
-        if info.script() != Script::Latin || (info.lang() != Lang::Eng && info.confidence() > 0.93)
-        {
-          println!("\nSkipping Para: {}", &detectable.replace("\n", ""));
-          println!(
-            "Script: {:?}; Lang: {:?}; Confidence: {:?}",
-            info.script(),
-            info.lang(),
-            info.confidence()
-          );
-          continue 'paragraphs;
-        }
+      if data_helpers::invalid_for_english_latin(&paragraph.dnm) {
+        continue 'paragraphs;
       }
       'sentences: for mut sentence in paragraph.iter() {
         sentence_buffer = String::new();

--- a/examples/corpus_ams_para_model.rs
+++ b/examples/corpus_ams_para_model.rs
@@ -153,11 +153,15 @@ pub fn main() -> Result<(), Error> {
             env.to_string()
           }
         } else if let Some(ref prev_node) = prev_opt {
-          // if None AMS markup found, check for structural markup, or record as "other" in model
+          // if None AMS markup found, check for structural markup
           let env: StructuralEnv = prev_node.get_content().into();
+          if env == StructuralEnv::Other { // if Other markup, ignore
+            continue 'paragraphs;
+          }
           env.to_string()
         } else {
-          String::from("other")
+          // if no markup at all, ignore the paragraph, as we don't have reliable classification information
+          continue 'paragraphs;
         };
         paragraph_count += 1;
         thread_data.push((paragraph_buffer, ams_dir));

--- a/src/ams.rs
+++ b/src/ams.rs
@@ -56,7 +56,11 @@ pub enum StructuralEnv {
 
 impl From<String> for StructuralEnv {
   fn from(s: String) -> StructuralEnv {
-    let s : String = s.chars().filter(char::is_ascii_alphabetic).collect::<String>().to_lowercase();
+    let s: String = s
+      .chars()
+      .filter(char::is_ascii_alphabetic)
+      .collect::<String>()
+      .to_lowercase();
     if s.starts_with("abstract") {
       StructuralEnv::Abstract
     } else if s.starts_with("acknowledgement") {
@@ -73,13 +77,13 @@ impl From<String> for StructuralEnv {
       StructuralEnv::Introduction
     } else if s.starts_with("keywords") {
       StructuralEnv::Keywords
-    } else if s.starts_with("literature review") {
+    } else if s.starts_with("literaturereview") {
       StructuralEnv::RelatedWork
     } else if s.starts_with("method") || s.ends_with("methods") {
       StructuralEnv::Method
     } else if s.starts_with("overview") {
       StructuralEnv::Overview
-    } else if s.starts_with("related work") {
+    } else if s.starts_with("relatedwork") {
       StructuralEnv::RelatedWork
     } else if s.starts_with("result") || s.ends_with("results") {
       StructuralEnv::Result

--- a/src/ams.rs
+++ b/src/ams.rs
@@ -108,46 +108,96 @@ impl fmt::Display for StructuralEnv {
 pub enum AmsEnv {
   /// typically co-author support for a proof/paper (also "thanks")
   Acknowledgement,
-  /// usually defines a computer science algorithm
+  /// usually defines a computer science algorithm (also "heuristic"; arXiv data is bad quality, would not recommend using)
   Algorithm,
-  /// assumption/axiom/assertion/prior
+  /// To be analyzed (?)
+  Answer,
+  /// To be analyzed (?)
+  Affirmation,
+  /// assumption/axiom/assertion/prior -- should they be included in propositions? Are they separable?
   Assumption,
-  /// usually an actual Figure or Table captions realized via AMS - strange, hopefully rare
+  /// To be analyzed (?)
+  Bound,
+  /// usually an actual Figure or Table captions realized via AMS (strange data, would not recommend using)
   Caption,
   /// A case in a multi-step proof / description / exposition
   Case,
+  /// To be analyzed (?)
+  Claim,
+  /// To be analyzed (?)
+  Comment,
+  /// To be analyzed (?)
+  Conclusion,
   /// Potentially a constraint on a proof
   Condition,
-  /// An unproven statement/theorem
+  /// An unproven statement/theorem (includes "conjecture", "ansatz", "guess", "hypothesis")
   Conjecture,
-  /// A trivial to prove consequence of a prior proof (also "hypothesis","ansatz")
+  /// To be analyzed (?)
+  Constraint,
+  /// To be analyzed (?)
+  Convention,
+  /// A direct-to-derive consequence of a prior proposition
   Corollary,
+  /// To be analyzed (?)
+  Criterion,
   /// Unlike notations, introduces new conceptual mathematical objects
   Definition,
-  /// Demonstration of a definition, notation etc
+  /// To be analyzed (?)
+  Demonstration,
+  /// To be analyzed (?)
+  Discussion,
+  /// Demonstration of a definition, notation etc (also "experiment")
   Example,
-  /// To be analyzed
+  /// To be analyzed (?)
+  Experiment,
+  /// To be analyzed (?)
+  Expansion,
+  /// To be analyzed (?)
+  Expectation,
+  /// To be analyzed (?)
+  Explanation,
+  /// To be analyzed (?)
   Fact,
+  /// To be analyzed (?)
+  Hint,
+  /// To be analyzed (?)
+  Issue,
+  /// To be analyzed (?)
+  Keywords,
   /// A smaller sub-theorem to a main theorem
   Lemma,
   /// Introduces a new syntactic rule, usually for convenience / brevity
   Notation,
-  /// A named paragraph, without a clear standalone function (also "term", "convention")
+  /// To be analyzed (?)
+  Note,
+  /// To be analyzed (?)
+  Notice,
+  /// To be analyzed (?)
+  Observation,
+  /// A named paragraph, without a clear standalone function
   Paragraph,
-  /// A task to be solved (sometimes with solution following)
+  /// To be analyzed (?)
+  Principle,
+  /// A task to be solved (sometimes with solution following), includes "Exercise"
   Problem,
-  /// Proves a prior theorem/lemma, etc
+  /// Proves a prior theorem/lemma, etc (also "demonstration", "solution")
   Proof,
   /// A provably true/false statement. Is this a synonym to theorem in arXiv?
   Proposition,
-  /// (sometimes) initial goal of inquiry
+  /// (sometimes) initial goal of inquiry (also "puzzle", "query")
   Question,
-  /// A comment that is an aside to the main line of reasoning.
+  /// A comment that is an aside to the main line of reasoning. (also "observation", "hint", "comment")
   Remark,
-  /// Summarizes the achieved deliverables of a document's derivations
+  /// Summarizes paper's experimental deliverables
   Result,
+  /// To be analyzed (?)
+  Rule,
+  /// To be analyzed (?)
+  Solution,
   /// A part of a proof, or demonstration/layout
   Step,
+  /// To be analyzed (?)
+  Summary,
   /// A main proposition to be proven in the document
   Theorem,
   /// Anything else that was marked up with AMS, but doesn't fit this scheme
@@ -156,30 +206,56 @@ pub enum AmsEnv {
 
 impl fmt::Display for AmsEnv {
   fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    use AmsEnv::*;
     let val = match self {
-      AmsEnv::Acknowledgement => "acknowledgement",
-      AmsEnv::Algorithm => "algorithm",
-      AmsEnv::Assumption => "assumption",
-      AmsEnv::Caption => "caption",
-      AmsEnv::Case => "case",
-      AmsEnv::Condition => "condition",
-      AmsEnv::Conjecture => "conjecture",
-      AmsEnv::Corollary => "corollary",
-      AmsEnv::Definition => "definition",
-      AmsEnv::Example => "example",
-      AmsEnv::Fact => "fact",
-      AmsEnv::Lemma => "lemma",
-      AmsEnv::Notation => "notation",
-      AmsEnv::Paragraph => "paragraph",
-      AmsEnv::Problem => "problem",
-      AmsEnv::Proof => "proof",
-      AmsEnv::Proposition => "proposition",
-      AmsEnv::Question => "question",
-      AmsEnv::Remark => "remark",
-      AmsEnv::Result => "result",
-      AmsEnv::Step => "step",
-      AmsEnv::Theorem => "theorem",
-      AmsEnv::Other => "other",
+      Acknowledgement => "acknowledgement",
+      Affirmation => "affirmation",
+      Algorithm => "algorithm",
+      Answer => "answer",
+      Assumption => "assumption",
+      Bound => "bound",
+      Caption => "caption",
+      Case => "case",
+      Claim => "claim",
+      Comment => "comment",
+      Conclusion => "conclusion",
+      Condition => "condition",
+      Conjecture => "conjecture",
+      Constraint => "constraint",
+      Convention => "convention",
+      Corollary => "corollary",
+      Criterion => "criterion",
+      Definition => "definition",
+      Demonstration => "demonstration",
+      Discussion => "discussion",
+      Example => "example",
+      Expansion => "expansion",
+      Expectation => "expectation",
+      Experiment => "experiment",
+      Explanation => "explanation",
+      Fact => "fact",
+      Hint => "hint",
+      Issue => "issue",
+      Keywords => "keywords",
+      Lemma => "lemma",
+      Notation => "notation",
+      Note => "note",
+      Notice => "notice",
+      Observation => "observation",
+      Other => "other",
+      Paragraph => "paragraph",
+      Principle => "principle",
+      Problem => "problem",
+      Proof => "proof",
+      Proposition => "proposition",
+      Question => "question",
+      Remark => "remark",
+      Result => "result",
+      Rule => "rule",
+      Solution => "solution",
+      Step => "step",
+      Summary => "summary",
+      Theorem => "theorem",
     };
     fmt.write_str(val)
   }
@@ -216,6 +292,7 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     "ack" | "ackn" | "ackno" | "acknow" | "acknowledge" | "acknowledgement"
     | "acknowledgements" | "acknowledgment" | "acknowledgments" | "acknowlegement" | "acks"
     | "thanks" => AmsEnv::Acknowledgement,
+    "affirmation" => AmsEnv::Affirmation,
     "algm" | "alg" | "algo" | "algo1" | "algor" | "algor0" | "algorithm" | "algorithm1"
     | "algorithm2" | "algorithmdef" | "algorithme" | "algorithms" | "algoritmo"
     | "inneralgorithm" | "algx" | "heu" | "heur" | "heuristic" | "heuristics" | "myalgo"
@@ -229,6 +306,8 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "ass1"
     | "asse"
     | "asser"
+    | "assert"
+    | "assertion"
     | "asslab"
     | "assm"
     | "assn"
@@ -278,6 +357,7 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "myassump"
     | "myassumption"
     | "nnassumption"
+    | "notationassumption"
     | "notationassumptions"
     | "number"
     | "postulate"
@@ -289,11 +369,22 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "simplifyingassumption"
     | "standingassumption"
     | "subsubaxiom" => AmsEnv::Assumption,
+    "bound" => AmsEnv::Bound,
     "diag" | "fig" | "figcaption" | "figm" | "fignum" | "figure" | "figuretext" | "tab"
     | "tabel" | "tabl" | "tabla" | "table" | "tldiag" => AmsEnv::Caption,
     "case" | "case1" | "case2" | "case3" | "caseone" | "casestudy" | "casetwo"
     | "innercustomcase" | "mycase" | "scase" | "sscase" | "subcase" | "subcase2" | "subsubcase"
     | "subsubsubcase" | "tcase" => AmsEnv::Case,
+    "aclaim" | "alphaclaim" | "boldclaim" | "cclaim" | "cdellsclaim" | "cdtopiclaim" | "cla" | "clai"
+    | "claim" | "claim1" | "claim2" | "claim3" | "claim4" | "claim5" | "claima" | "claimapp"
+    | "claimb" | "claimc" | "claimenv" | "claimfoo" | "claimi" | "claimlncs" | "claimm" | "claimn"
+    | "claimnn" | "claimno" | "claimnr" | "claimnum" | "claimone" | "claimprop3" | "claimq"
+    | "claims" | "claimstar" | "claimsub" | "claimx" | "clm" | "defclaim" | "innercustomclaim"
+    | "internalclaim" | "itclaim" | "jmclaim" | "lblclaim" | "mainclaim" | "mclaim" | "megaclaim"
+    | "misclaim" | "myclaim" |  "nclaim" |  "newclaim" |  "numberedclaim" |  "numclaim" |  "ourclaim"
+    | "pclaim" | "prclaim" | "preclaim" | "procclaim" | "proclaim" | "proclaimmydef"
+    | "quasiclaim" | "sclaim" | "proclaimmypreuve" | "subclai" | "subclaim" | "tclaim" | "tittoclaim"
+    | "uclaim" | "varclaim" | "xclaim" => AmsEnv::Claim,
     "clcriterion" | "cnd" | "cond" | "condi" | "condition" | "conditiona" | "conditionb"
     | "conditionc" | "conditions" | "condn" | "conds" | "crit" | "criteria" | "innercondition"
     | "lcon" | "mycond" | "ncond" | "ocond" | "xcondition" => AmsEnv::Condition,
@@ -308,6 +399,7 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "introconjecture" | "itconjecture" | "mainconj" | "mainconjecture" | "mconj" | "myconj"
     | "myconjecture" | "ourconjecture" | "precon" | "preconj" | "rconjecture" | "sconj"
     | "sconjecture" | "subconj" => AmsEnv::Conjecture,
+    "conv" | "conve" | "conventie" | "convention" | "conventionfoo" | "conventionn" | "conventions" => AmsEnv::Convention,
     "acorollary" | "apulause" | "bcorollary" | "bigcorollary" | "ccor" | "ccoro" | "ccorollary"
     | "cl" | "cllry" | "cnv" | "co" | "col" | "coll" | "collary" | "collolary" | "collorary"
     | "coly" | "comq" | "coor" | "cor" | "cor0" | "cor1" | "cor2" | "cor3" | "cor4" | "cor5"
@@ -335,6 +427,7 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "rmkk" | "scor" | "scorol" | "scorollary" | "subcorollary" | "supos" | "tcor"
     | "tcorollary" | "tem" | "theorex" | "thmcorollary" | "uncorollary" | "wn" | "xcor"
     | "xcorollary" => AmsEnv::Corollary,
+    "criterion" => AmsEnv::Criterion,
     "1def"
     | "adefi"
     | "adefinition"
@@ -638,6 +731,8 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "xdefinition"
     | "xdefn"
     | "xtdef" => AmsEnv::Definition,
+    "demonstration" => AmsEnv::Demonstration,
+    "disc" | "discussion" | "notationanddiscussion" => AmsEnv::Discussion,
     "appexample" | "backtheorem" | "baseexample" | "beispiel" | "bexample" | "bigexample"
     | "bp" | "bsp" | "bsp1" | "bspe" | "cexample" | "cexpl" | "conda" | "counterexample"
     | "csexample" | "dexample" | "e1" | "eexam" | "eexample" | "eexemples" | "eg" | "ejem"
@@ -652,7 +747,7 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "exampleth" | "examplex" | "examplit" | "examps" | "exams" | "exas" | "exaxxx" | "exe"
     | "exe1" | "exem" | "exem2" | "exemp" | "exempl" | "exemple" | "exemplo" | "exex" | "exm"
     | "exmatmul" | "exmp" | "exmp3" | "exmpl" | "exmple" | "exmples" | "exmps" | "exp"
-    | "expansion" | "expe" | "expectation" | "experiment" | "expl" | "expl2" | "explanation"
+    | "expe" | "expl" | "expl2"
     | "exple" | "explo" | "expls" | "expltemap" | "exz" | "fexample" | "hexample" | "iexample"
     | "innercontexample" | "innerexample" | "introexample" | "itexample" | "mainex"
     | "mainexample" | "mexample" | "miex" | "minorexmp" | "myexam" | "myexample"
@@ -660,9 +755,13 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "nonexample" | "numberedexample" | "numexample" | "nxmpl" | "orexample" | "plcexample"
     | "preex" | "preexample" | "preexamples" | "prexample" | "proexample" | "rexample"
     | "rrexampleraw" | "runex" | "runningexample" | "sexample" | "subexample" | "texample"
-    | "textofexample" | "theexample" | "theoremnl" | "varexample" | "xexample" | "xmpl" => {
-      AmsEnv::Example
-    }
+    | "textofexample" | "theexample" | "theoremnl" | "varexample" | "xexample" | "xmpl" =>
+      AmsEnv::Example,
+    "experiment" => AmsEnv::Experiment,
+    "explanation" => AmsEnv::Explanation,
+    "expansion" => AmsEnv::Expansion,
+    "expectation" => AmsEnv::Expectation,
+    "principle" => AmsEnv::Principle,
     "algrule"
     | "arule"
     | "branchrule"
@@ -670,9 +769,34 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "brule"
     | "coordinates"
     | "crule"
-    | "definitionandfact"
     | "drule"
-    | "edgerule"
+    | "grule"
+    | "intruler"
+    | "intrules"
+    | "kernelrule"
+    | "krule"
+    | "mrule"
+    | "myrule"
+    | "polyrule"
+    | "pruningrule"
+    | "qrule"
+    | "redrule"
+    | "redrulebgvd"
+    | "reducerule"
+    | "reductionrule"
+    | "rerule"
+    | "rle"
+    | "rrule"
+    | "rul"
+    | "rule"
+    | "rule0"
+    | "rules"
+    | "rull"
+    | "syntaxrule"
+    | "trule"
+    | "validrule"
+    | "edgerule" => AmsEnv::Rule,
+    | "definitionandfact"
     | "fac"
     | "fact"
     | "fact2"
@@ -685,47 +809,23 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "factsub"
     | "factt"
     | "fakt"
+    | "factfoo"
     | "faktum"
     | "fct"
     | "ffact"
-    | "grule"
     | "hfakt"
-    | "intruler"
-    | "intrules"
-    | "kernelrule"
-    | "krule"
-    | "mrule"
     | "myfact"
-    | "myrule"
     | "nfact"
-    | "nsfactor"
     | "ourfact"
-    | "polyrule"
-    | "principle"
     | "profact"
-    | "pruningrule"
-    | "qrule"
-    | "redrule"
-    | "redrulebgvd"
-    | "reducerule"
-    | "reductionrule"
-    | "rerule"
-    | "rle"
     | "romanfact"
-    | "rrule"
-    | "rul"
-    | "rule"
-    | "rule0"
-    | "rules"
-    | "rull"
     | "sfact"
     | "stylizedfact"
-    | "subfact"
-    | "syntaxrule"
-    | "trule"
-    | "validrule" => AmsEnv::Fact,
+    | "subfact" => AmsEnv::Fact,
+    "issue" => AmsEnv::Issue,
+    "keywords" => AmsEnv::Keywords,
     "alemma" | "aplemma" | "appendixlemma" | "applemma" | "approximationlemma" | "appxlem"
-    | "appxlemma" | "aslemma" | "assumptions" | "bigclm" | "blemma" | "criterion" | "defilemma"
+    | "appxlemma" | "aslemma" | "assumptions" | "bigclm" | "blemma" | "defilemma"
     | "definitionlemma" | "deflemma" | "defnlem" | "dlemma" | "elem" | "elemme" | "envlem"
     | "exampletheoremenv" | "fiebiglemma" | "flemma" | "frmlemmasup" | "glemma"
     | "innercustomlem" | "innercustomlemma" | "intlemnp" | "itlemma" | "keylem" | "keylemma"
@@ -744,33 +844,23 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "lemmaux" | "lemmax" | "lemme" | "lemme1" | "lemme2" | "lemming" | "lemmino" | "lemmm"
     | "lemmma" | "lemms" | "lemmx" | "lemmy" | "lemo" | "lemqed" | "lems" | "lemsec"
     | "letterlemma" | "lkadlemma" | "ll" | "llemma" | "lm" | "lma" | "lmb" | "lmm" | "lmm1"
-    | "lmm2" | "lmma" | "lmmno" | "lms" | "locallemma" | "mainlem" | "mlem" | "mlemma"
+    | "lmm2" | "lmma" | "lmmno" | "lms" | "locallemma" | "mainlem" | "mainlemma" | "mlem" | "mlemma"
     | "monlem" | "mydlem3" | "mylem" | "mylemm" | "mylemma" | "mylm" | "mylma" | "mylmm"
     | "newlemma" | "nlemma" | "nnlemma" | "nolem" | "nonolemma" | "nonumberlemma"
     | "nonumlemma" | "ntlemma" | "oldlemma" | "ourlemma" | "palemma" | "plemma" | "prealphlem"
-    | "prelem" | "prelemm" | "prelemma" | "prolemma" | "quasilemma" | "quot" | "remark4"
+    | "prelem" | "prelemm" | "prelemma" | "prolemma" | "quasilemma" | "quot"
     | "replemma" | "rmlemma" | "rmlemmaplain" | "seclemma" | "slemma" | "slemme" | "souslemme"
     | "starex" | "steplemma" | "sub" | "sublem" | "sublema" | "sublemm" | "sublemma" | "sublm"
     | "subsublemma" | "suplemma" | "technicallemma" | "textoflemma" | "theirlemma" | "thmlemma"
     | "tlemma" | "twistinglemma" | "unnumberedlemma" | "xlem" | "xlemm" | "xlemma"
     | "zamechanie" => AmsEnv::Lemma,
-    "bound"
-    | "bsubnotation"
-    | "config"
-    | "conv"
-    | "conve"
-    | "conventie"
-    | "convention"
-    | "conventionfoo"
-    | "conventionn"
-    | "conventions"
-    | "defbemerkung"
-    | "definite"
+    // | "config" ??
+    // | "defbemerkung" ??
+    // | "definite" ??
+    // | "df" ??
+    "bsubnotation"
     | "definitionnotation"
-    | "df"
-    | "keywords"
     | "localnotation"
-    | "mainlemma"
     | "name"
     | "naming"
     | "nb"
@@ -784,7 +874,6 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "notation"
     | "notation0"
     | "notationa"
-    | "notationanddiscussion"
     | "notationandreminder"
     | "notationdefinition"
     | "notationn"
@@ -799,7 +888,6 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "prenotation"
     | "prerem"
     | "protobody"
-    | "question"
     | "remarkaux"
     | "remnotation"
     | "setting"
@@ -826,13 +914,13 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "sect"
     | "subparag"
     | "subsec" => AmsEnv::Paragraph,
-    "bwexerc"
-    | "classproblem"
+    "classproblem"
     | "condb"
     | "coreproblem"
     | "corollaryin"
     | "cproblem"
     | "eioproblem"
+    | "bwexerc"
     | "exc"
     | "exer"
     | "exercice"
@@ -898,62 +986,22 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "xca"
     | "xopen" => AmsEnv::Problem,
     "afirmativa" | "beweis" | "claimproof" | "clproof" | "cproof" | "cproofa" | "cproofb"
-    | "demonstration" | "eproof" | "lemproof" | "mproof" | "myproo" | "myproof" | "namedproof"
+    | "eproof" | "lemproof" | "mproof" | "myproo" | "myproof" | "namedproof"
     | "notationinproof" | "oldproof" | "pf" | "pprf" | "preproof" | "preprooff" | "prf"
     | "proof" | "proof0" | "proof1" | "proof2" | "proof3" | "proof4" | "proof5" | "proofa"
     | "proofaux" | "proofcase" | "proofclaim" | "prooff" | "prooffact" | "proofhead"
     | "proofidea" | "prooflem" | "proofn" | "proofof" | "proofoftheorem" | "proofpart"
     | "proofprop" | "proofsketch" | "proofth" | "prooftheorem" | "proofthm" | "proofx"
-    | "sketchofproof" | "solution" | "solutions" | "theoremproof" | "xproof" => AmsEnv::Proof,
+    | "sketchofproof" | "theoremproof" | "xproof" => AmsEnv::Proof,
     "5proposition"
-    | "a4"
-    | "a5"
-    | "aclaim"
-    | "affirmation"
-    | "alphaclaim"
+    // | "a4"
+    // | "a5"
     | "approp"
     | "appxprop"
     | "aprop"
     | "aproposition"
-    | "assert"
-    | "assertion"
-    | "boldclaim"
     | "bproposition"
-    | "cclaim"
-    | "cdellsclaim"
-    | "cdtopiclaim"
-    | "cla"
-    | "clai"
-    | "claim"
-    | "claim1"
-    | "claim2"
-    | "claim3"
-    | "claim4"
-    | "claim5"
-    | "claima"
-    | "claimapp"
-    | "claimb"
-    | "claimc"
-    | "claimenv"
-    | "claimfoo"
-    | "claimi"
-    | "claimlncs"
-    | "claimm"
-    | "claimn"
-    | "claimnn"
-    | "claimno"
-    | "claimnr"
-    | "claimnum"
-    | "claimone"
-    | "claimprop3"
-    | "claimq"
-    | "claims"
-    | "claimstar"
-    | "claimsub"
-    | "claimx"
-    | "clm"
     | "dclprop"
-    | "defclaim"
     | "definitionproposition"
     | "defiprop"
     | "defnprop"
@@ -970,49 +1018,39 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "fsprop"
     | "gproposition"
     | "gstatement"
+    | "statement"
+    | "stmt"
+    | "subprop"
     | "hprop"
     | "hproposition"
     | "hyllprop"
-    | "innercustomclaim"
     | "innercustomprop"
     | "innercustomproposition"
-    | "internalclaim"
     | "introprop"
     | "introproposition"
     | "iprop"
     | "iproposition"
-    | "issue"
-    | "itclaim"
     | "itproposition"
-    | "jmclaim"
     | "kmprop"
     | "kspproposition"
-    | "l3"
-    | "lblclaim"
+    // | "l3"
     | "lprop"
     | "lproposition"
-    | "mainclaim"
     | "mainprop"
     | "mainproposition"
     | "maprop"
     | "mathproposition"
-    | "mclaim"
     | "mdprop"
-    | "megaclaim"
-    | "misclaim"
     | "mpro"
     | "mprop"
     | "mproposition"
     | "msproposition"
-    | "myclaim"
     | "myprop"
     | "mypropd"
-    | "myproperty"
     | "myproposition"
     | "myprp"
+    | "myproperty"
     | "namedprop"
-    | "nclaim"
-    | "newclaim"
     | "newprop"
     | "newproposition"
     | "nnprop"
@@ -1020,14 +1058,10 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "nonumberproposition"
     | "nprop"
     | "nproposition"
-    | "num"
-    | "numberedclaim"
-    | "numclaim"
+    // | "num" ?
     | "numprop"
-    | "ourclaim"
     | "ourproposition"
     | "p"
-    | "pclaim"
     | "pn"
     | "pp"
     | "ppn"
@@ -1038,8 +1072,6 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "pr1"
     | "pr4"
     | "pr5"
-    | "prclaim"
-    | "preclaim"
     | "pred"
     | "predl"
     | "prepos"
@@ -1052,10 +1084,6 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "pro3"
     | "pro4"
     | "pro5"
-    | "procclaim"
-    | "proclaim"
-    | "proclaimmydef"
-    | "proclaimmypreuve"
     | "prop"
     | "prop0"
     | "prop1"
@@ -1184,122 +1212,52 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "prpsubf"
     | "prpt"
     | "prrop"
-    | "quasiclaim"
-    | "refine"
     | "refprop"
-    | "restatement"
     | "sat"
     | "sbprop"
-    | "sclaim"
     | "secprop"
     | "sectionprop"
     | "spprop"
     | "spropo"
     | "sproposition"
+    | "refine"
+    | "restatement"
     | "state"
     | "statem"
     | "statement1"
     | "statm"
     | "statment"
     | "stprop"
-    | "strengths"
+    // | "strengths"
     | "stw"
-    | "subclai"
-    | "subclaim"
     | "subproperty"
     | "subproposition"
     | "subprops"
     | "supproposition"
     | "surprop"
-    | "tclaim"
     | "tempprop"
     | "thp"
     | "thprop"
-    | "tittoclaim"
     | "tprop"
-    | "uclaim"
-    | "varclaim"
     | "varprop"
-    | "weaknesses"
+    // | "weaknesses"
     | "wproposition"
-    | "xclaim"
     | "xprop"
     | "xproposition" => AmsEnv::Proposition,
     "boldquestion" | "emquestion" | "innerquestion" | "introquestion" | "mainquestion"
     | "myquest" | "myquestion" | "op" | "openquestion" | "prequestion" | "puzzle" | "q" | "qn"
     | "qst" | "qstn" | "qtn" | "qu" | "que" | "que1" | "query" | "ques" | "quesb" | "quess"
-    | "quest" | "quest0" | "question0" | "question1" | "question2" | "question3"
+    | "quest" | "quest0" | "question" | "question0" | "question1" | "question2" | "question3"
     | "questionapp" | "questionb" | "questioni" | "questionintro" | "questions" | "queststar"
-    | "remarques" | "remarquesubsect" | "researchquestion" | "rquestion" | "subquestion"
-    | "varquestion" | "vopros" => AmsEnv::Question,
-    "a3remark"
-    | "advice"
-    | "aremark"
-    | "auxremark"
-    | "baseremark"
-    | "bem"
-    | "bemerkung"
-    | "bigremark"
-    | "bremark"
-    | "bremarknote"
-    | "brmk"
-    | "bsubremarknote"
-    | "comment"
-    | "commentary"
-    | "comments"
-    | "context"
-    | "definitionandremark"
-    | "definitionremark"
-    | "defremark"
-    | "deno"
-    | "disc"
-    | "discussion"
-    | "dummyrem"
-    | "emrem"
-    | "emremark"
-    | "eremark"
-    | "factfoo"
-    | "hint"
-    | "introremark"
-    | "iremark"
-    | "itremark"
-    | "kmremark"
-    | "lnote"
+    | "researchquestion" | "rquestion" | "subquestion" | "varquestion" | "vopros" => AmsEnv::Question,
+    // Extracted from original big parent Remark category:
+    "mycomment"| "comment" | "commentary" | "comments" => AmsEnv::Comment,
+    "note" | "lnote" | "mynote" => AmsEnv::Note,
+    "notice" => AmsEnv::Notice,
+    "hint" => AmsEnv::Hint,
     | "localobservation"
-    | "localremark"
-    | "mcc"
-    | "miniremark"
-    | "mirem"
-    | "mrem"
-    | "mremark"
-    | "mycomment"
-    | "mynote"
     | "myobservation"
     | "myoss"
-    | "myrek"
-    | "myrem"
-    | "myrema"
-    | "myremark"
-    | "myremarks"
-    | "myrems"
-    | "myrm"
-    | "myrmk"
-    | "newremark"
-    | "nnremark"
-    | "nota"
-    | "notationandremark"
-    | "notationassumption"
-    | "note"
-    | "notice"
-    | "nremark"
-    | "nrmk"
-    | "nrmks"
-    | "nrmrk"
-    | "ntremark"
-    | "numberedremark"
-    | "numremark"
-    | "numrk"
-    | "numrmk"
     | "ob"
     | "obs"
     | "observ"
@@ -1317,15 +1275,68 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "osserv"
     | "osserva"
     | "osservazione"
-    | "para"
+    | "preobserv" => AmsEnv::Observation,
+    "summary" => AmsEnv::Summary,
+    "a3remark"
+    // | "advice" ???
+    | "aremark"
+    | "auxremark"
+    | "baseremark"
+    | "bem"
+    | "bemerkung"
+    | "bigremark"
+    | "bremark"
+    | "bremarknote"
+    | "brmk"
+    | "bsubremarknote"
+    // | "context" ???
+    // | "definitionandremark" ??? (between classes)
+    | "definitionremark"
+    | "defremark"
+    | "deno"
+    | "dummyrem"
+    | "emrem"
+    | "emremark"
+    | "eremark"
+    | "introremark"
+    | "iremark"
+    | "itremark"
+    | "kmremark"
+    | "localremark"
+    | "mcc"
+    | "miniremark"
+    | "mirem"
+    | "mrem"
+    | "mremark"
+    | "myrek"
+    | "myrem"
+    | "myrema"
+    | "myremark"
+    | "myremarks"
+    | "myrems"
+    | "myrm"
+    | "myrmk"
+    | "newremark"
+    | "nnremark"
+    // | "nota" ???
+    // | "notationandremark" ??? (between classes)
+    | "nremark"
+    | "nrmk"
+    | "nrmks"
+    | "nrmrk"
+    | "ntremark"
+    | "numberedremark"
+    | "numremark"
+    | "numrk"
+    | "numrmk"
+    // | "para" ???
+    // "point" => AmsEnv::Point,
     | "plainremarks"
-    | "point"
-    | "preobserv"
     | "preremark"
     | "preremark2"
     | "proremark"
     | "protoremark"
-    | "punto"
+    // | "punto"
     | "r"
     | "re"
     | "reem"
@@ -1343,6 +1354,7 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "remark1"
     | "remark2"
     | "remark3"
+    | "remark4"
     | "remark5"
     | "remark6"
     | "remarka"
@@ -1385,8 +1397,7 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "remarkunnumbered"
     | "remarkwr"
     | "remarkx"
-    | "remarq"
-    | "remarque"
+    | "remarq" | "remarque" | "remarques" | "remarquesubsect"
     | "remarque2"
     | "rembold"
     | "reme"
@@ -1421,18 +1432,14 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "rqe1"
     | "rque"
     | "rremark"
-    | "say"
+    // | "say" ???
     | "sideremark"
     | "sidermk"
-    | "sit"
+    // | "sit" ???
     | "smallremark"
     | "sremark"
     | "srmk"
-    | "statement"
-    | "stmt"
-    | "subprop"
     | "subremark"
-    | "summary"
     | "thremark"
     | "topology"
     | "torsionremark"
@@ -1448,11 +1455,12 @@ pub fn normalize_env(env: &str) -> AmsEnv {
     | "xremark"
     | "xrmk"
     | "zero" => AmsEnv::Remark,
-    "answer" | "conclude" | "conclusion" | "conclusions" | "final" | "mainresult" | "mdresult"
-    | "numres" | "priorresults" | "res" | "resu" | "resul" | "result" | "resultat" | "results"
-    | "resump" => AmsEnv::Result,
-    "art" | "astep" | "chunk" | "cons" | "constr" | "constraint" | "constraints"
-    | "constrinternal" | "construct" | "construction" | "constructions" | "cstep" | "emf"
+    "answer" => AmsEnv::Answer,
+    "conclude" | "conclusion" | "conclusions" => AmsEnv::Conclusion,
+    "final" | "mainresult" | "mdresult" | "numres" | "priorresults" | "res" | "resu" | "resul" | "result" | "resultat" | "results" | "resump" => AmsEnv::Result,
+    "solution" | "solutions" => AmsEnv::Solution,
+    "cons" | "constr" | "constraint" | "constraints" | "constrinternal" => AmsEnv::Constraint,
+    "art" | "astep" | "chunk" | "construct" | "construction" | "constructions" | "cstep" | "emf"
     | "nothing" | "ournothing" | "pstep" | "reduction" | "require" | "stage" | "step" | "step1"
     | "step2" | "step3" | "step4" | "step5" | "stepa" | "stepb" | "stepmain" | "stepn"
     | "stepnamed" | "stepnn" | "stepp" | "stepwise" | "substep" | "ttt" => AmsEnv::Step,

--- a/src/ams.rs
+++ b/src/ams.rs
@@ -28,53 +28,61 @@ pub fn has_markup_xmldoc(dom: &XmlDoc) -> bool {
 pub enum StructuralEnv {
   /// abstract lead-in
   Abstract,
-  /// Introduction section
+  /// Acknowledgement(.+) section
+  Acknowledgement,
+  /// Conclusion(.+) section
+  Conclusion,
+  /// Discussion(.+) section
+  Discussion,
+  /// Example(.+) section
+  Example,
+  /// Exercise(.+) section
+  Exercise,
+  /// Introduction(.+) section
   Introduction,
-  /// Related Work section
+  /// Keywords metadata from paper frontmatter
+  Keywords,
+  /// Related Work/Literature Review(.+) section
   RelatedWork,
   /// Method(s) section
   Method,
-  /// Remark(.+) section
-  Remark,
-  /// Caption for a figure or table
-  Caption, // figcaption element, skip ltx_tag_figure span, auto-generated
-  /// Example(.+) section
-  Example,
-  /// Result(.+) section
+  /// Overview(.+) sections
+  Overview,
+  /// Result(s) section
   Result,
-  /// Discussion(.+) section
-  Discussion,
-  /// Conclusion(.+) section
-  Conclusion,
-  /// Acknowledgement(s) section
-  Acknowledgement,
   /// Anything else
   Other,
 }
 
 impl From<String> for StructuralEnv {
   fn from(s: String) -> StructuralEnv {
-    let s = s.to_lowercase();
+    let s : String = s.chars().filter(char::is_ascii_alphabetic).collect::<String>().to_lowercase();
     if s.starts_with("abstract") {
       StructuralEnv::Abstract
-    } else if s.starts_with("introduction") {
-      StructuralEnv::Introduction
-    } else if s.starts_with("related work") {
-      StructuralEnv::RelatedWork
-    } else if s.starts_with("method") {
-      StructuralEnv::Method
-    } else if s.starts_with("remark") {
-      StructuralEnv::Remark
-    } else if s.starts_with("example") {
-      StructuralEnv::Example
-    } else if s.starts_with("result") {
-      StructuralEnv::Result
-    } else if s.starts_with("discussion") {
-      StructuralEnv::Discussion
-    } else if s.starts_with("conclusion") {
-      StructuralEnv::Conclusion
     } else if s.starts_with("acknowledgement") {
       StructuralEnv::Acknowledgement
+    } else if s.starts_with("conclusion") {
+      StructuralEnv::Conclusion
+    } else if s.starts_with("discussion") {
+      StructuralEnv::Discussion
+    } else if s.starts_with("example") {
+      StructuralEnv::Example
+    } else if s.starts_with("exercise") {
+      StructuralEnv::Exercise
+    } else if s.starts_with("introduction") {
+      StructuralEnv::Introduction
+    } else if s.starts_with("keywords") {
+      StructuralEnv::Keywords
+    } else if s.starts_with("literature review") {
+      StructuralEnv::RelatedWork
+    } else if s.starts_with("method") || s.ends_with("methods") {
+      StructuralEnv::Method
+    } else if s.starts_with("overview") {
+      StructuralEnv::Overview
+    } else if s.starts_with("related work") {
+      StructuralEnv::RelatedWork
+    } else if s.starts_with("result") || s.ends_with("results") {
+      StructuralEnv::Result
     } else {
       StructuralEnv::Other
     }
@@ -85,16 +93,17 @@ impl fmt::Display for StructuralEnv {
   fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
     let val = match self {
       StructuralEnv::Abstract => "abstract",
+      StructuralEnv::Acknowledgement => "acknowledgement",
+      StructuralEnv::Conclusion => "conclusion",
+      StructuralEnv::Discussion => "discussion",
+      StructuralEnv::Example => "example",
+      StructuralEnv::Exercise => "exercise",
       StructuralEnv::Introduction => "introduction",
+      StructuralEnv::Keywords => "keywords",
       StructuralEnv::RelatedWork => "relatedwork",
       StructuralEnv::Method => "method",
-      StructuralEnv::Remark => "remark",
-      StructuralEnv::Caption => "caption",
-      StructuralEnv::Example => "example",
+      StructuralEnv::Overview => "overview",
       StructuralEnv::Result => "result",
-      StructuralEnv::Discussion => "discussion",
-      StructuralEnv::Conclusion => "conclusion",
-      StructuralEnv::Acknowledgement => "acknowledgement",
       StructuralEnv::Other => "other",
     };
     fmt.write_str(val)

--- a/src/ams.rs
+++ b/src/ams.rs
@@ -24,6 +24,7 @@ pub fn has_markup_xmldoc(dom: &XmlDoc) -> bool {
 
 /// Semantically fixed structural environments in scientific documents, to collect as
 /// counter-balance to the AMS markup
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StructuralEnv {
   /// abstract lead-in
   Abstract,
@@ -104,7 +105,7 @@ impl fmt::Display for StructuralEnv {
 /// which are then transported in the HTML representation as `ltx_theorem_<env>`
 ///
 /// We shortlist 23 of the >20,000 variety of values present in the arXiv corpus
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum AmsEnv {
   /// typically co-author support for a proof/paper (also "thanks")
   Acknowledgement,
@@ -180,13 +181,13 @@ pub enum AmsEnv {
   Principle,
   /// A task to be solved (sometimes with solution following), includes "Exercise"
   Problem,
-  /// Proves a prior theorem/lemma, etc (also "demonstration", "solution")
+  /// Proves a prior theorem/lemma
   Proof,
   /// A provably true/false statement. Is this a synonym to theorem in arXiv?
   Proposition,
   /// (sometimes) initial goal of inquiry (also "puzzle", "query")
   Question,
-  /// A comment that is an aside to the main line of reasoning. (also "observation", "hint", "comment")
+  /// A comment that is an aside to the main line of reasoning
   Remark,
   /// Summarizes paper's experimental deliverables
   Result,

--- a/src/util/data_helpers.rs
+++ b/src/util/data_helpers.rs
@@ -53,18 +53,21 @@ pub fn ams_normalize_word_range(range: &DNMRange, mut context: &mut Context) -> 
 
 /// Check if the given DNM contains valid English+Latin content
 pub fn invalid_for_english_latin(dnm: &dnm::DNM) -> bool {
-  let detectable_with_spaces = dnm.plaintext.replace("MathFormula", "");
+  let detectable_with_spaces = dnm
+    .plaintext
+    .replace("MathFormula", " ")
+    .replace("CitationElement", " ")
+    .replace("REF", " ");
   let detectable = detectable_with_spaces.trim();
   if let Some(info) = detect(&detectable) {
-    if info.script() != Script::Latin || (info.lang() != Lang::Eng && info.confidence() > 0.93)
-    {
-      println!("\nSkipping Para: {}", &detectable.replace("\n", ""));
-      println!(
-        "Script: {:?}; Lang: {:?}; Confidence: {:?}",
-        info.script(),
-        info.lang(),
-        info.confidence()
-      );
+    if info.script() != Script::Latin || (info.lang() != Lang::Eng && info.confidence() > 0.93) {
+      // println!("\nSkipping Para: {}", &detectable.replace("\n", ""));
+      // println!(
+      //   "Script: {:?}; Lang: {:?}; Confidence: {:?}",
+      //   info.script(),
+      //   info.lang(),
+      //   info.confidence()
+      // );
       true
     } else {
       false

--- a/src/util/data_helpers.rs
+++ b/src/util/data_helpers.rs
@@ -24,7 +24,7 @@ static MAX_WORD_LENGTH: usize = 25;
 /// - citations become citationelement
 /// - math is replaced by its lexeme annotation (created by latexml), with a "mathformula" fallback
 /// - of the word is longer than the max length of 25, an error is returned
-pub fn ams_normalize_word_range(range: &DNMRange, mut context: &mut Context) -> Result<String, ()> {
+pub fn ams_normalize_word_range(range: &DNMRange, mut context: &mut Context, discard_math: bool) -> Result<String, ()> {
   let mut word_string = range
     .get_plaintext()
     .chars()
@@ -41,7 +41,11 @@ pub fn ams_normalize_word_range(range: &DNMRange, mut context: &mut Context) -> 
   // sometimes they are not cleanly tokenized, e.g. $k$-dimensional
   // will be the word string "mathformula-dimensional"
   if word_string.contains("mathformula") {
-    word_string = dnm::node::lexematize_math(range.get_node(), &mut context);
+    if !discard_math {
+      word_string = dnm::node::lexematize_math(range.get_node(), &mut context);
+    } else {
+      word_string = String::new();
+    }
   } else if word_string.contains("citationelement") {
     word_string = String::from("citationelement");
   } else if IS_NUMERC.is_match(&word_string) {

--- a/src/util/path_helpers.rs
+++ b/src/util/path_helpers.rs
@@ -21,7 +21,7 @@ pub fn path_to_words(path: String) -> String {
       let mut sentence_buffer = String::new();
       for word in sentence.simple_iter() {
         if !word.range.is_empty() {
-          let word_string = match data_helpers::ams_normalize_word_range(&word.range, &mut context)
+          let word_string = match data_helpers::ams_normalize_word_range(&word.range, &mut context, false)
           {
             Ok(w) => w,
             Err(_) => {


### PR DESCRIPTION
Fixes #32 .

There are major improvements to controlling quality and de-noising the paragraphs extracted for the "AMS/mathematical statement" classification task. More details in the issue. This PR has already produced a dataset of 10.5 million paragraphs. Finish up downstream benchmarking and sanity checks, before merging here, more details in the issue.