### PR TITLE
[WIP] Parallel primitives upgrades: heading containers, refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,6 @@ jwalk = "0.4"
 whatlang = "0.7.0"
 
 [dev-dependencies]
+serde = {version = "1.0", features = ["derive"]}
+csv = "1.1"
 serde_json = "1.0"

--- a/examples/corpus_heading_stats.rs
+++ b/examples/corpus_heading_stats.rs
@@ -53,28 +53,21 @@ pub fn main() -> Result<(), Error> {
       }
       let mut heading_buffer = String::new();
       let mut invalid_heading = false;
-      'sentences: for mut sentence in heading.iter() {
-        let mut sentence_buffer = String::new();
-        for word in sentence.word_iter() {
-          if word.range.is_empty() {
-            continue;
-          }
-          let word_string =
-            match data_helpers::ams_normalize_word_range(&word.range, &mut context, false) {
-              Ok(w) => w,
-              Err(_) => {
-                overflow_count += 1;
-                invalid_heading = true;
-                break 'sentences;
-              }
-            };
-          if !word_string.is_empty() {
-            sentence_buffer.push_str(&word_string);
-            sentence_buffer.push(' ');
-          }
+      for word in heading.word_iter() {
+        if word.range.is_empty() {
+          continue;
         }
-        if !sentence_buffer.is_empty() {
-          heading_buffer.push_str(&sentence_buffer);
+        let word_string =
+          match data_helpers::ams_normalize_word_range(&word.range, &mut context, false) {
+            Ok(w) => w,
+            Err(_) => {
+              overflow_count += 1;
+              invalid_heading = true;
+              break;
+            }
+          };
+        if !word_string.is_empty() {
+          heading_buffer.push_str(&word_string);
           heading_buffer.push(' ');
         }
       }

--- a/examples/corpus_heading_stats.rs
+++ b/examples/corpus_heading_stats.rs
@@ -1,0 +1,127 @@
+// Copyright 2015-2019 KWARC research group. See the LICENSE
+// file at the top-level directory of this distribution.
+//
+/// Extracts a corpus heading model from an unpacked corpus of HTML files
+/// With math lexemes (default):
+/// $ cargo run --release --example corpus_heading_stats /path/to/corpus heading_data.tar
+use std::collections::HashMap;
+use std::env;
+use std::fs::File;
+use std::io::{BufWriter, Error};
+
+use libxml::xpath::Context;
+use llamapun::parallel_data::*;
+use llamapun::util::data_helpers;
+use serde::Serialize;
+
+static BUFFER_CAPACITY: usize = 10_485_760;
+
+#[derive(Debug, Serialize)]
+struct HeadingRecord<'a> {
+  heading: &'a str,
+  frequency: &'a u64,
+}
+
+pub fn main() -> Result<(), Error> {
+  let start = time::get_time();
+  // Read input arguments
+  let mut input_args = env::args();
+  let _ = input_args.next(); // skip process name
+  let corpus_path = match input_args.next() {
+    Some(path) => path,
+    None => "tests/resources/".to_string(),
+  };
+  let headings_report_filename = match input_args.next() {
+    Some(path) => path,
+    None => "headings_report_filename.csv".to_string(),
+  };
+
+  let corpus = Corpus::new(corpus_path);
+
+  let mut catalog = corpus.catalog_with_parallel_walk(|document| {
+    let mut heading_count: u64 = 0;
+    let mut overflow_count = 0;
+    let mut thread_counts = HashMap::new();
+    thread_counts.insert(String::from("total_document_count"), 1);
+
+    let mut context = Context::new(&document.dom).unwrap();
+
+    'headings: for mut heading in document.heading_iter() {
+      // Before we go into tokenization, ensure this is an English sentence on the math-normalized plain text.
+      if data_helpers::invalid_for_english_latin(&heading.dnm) {
+        continue 'headings;
+      }
+      let mut heading_buffer = String::new();
+      let mut invalid_heading = false;
+      'sentences: for mut sentence in heading.iter() {
+        let mut sentence_buffer = String::new();
+        for word in sentence.word_iter() {
+          if word.range.is_empty() {
+            continue;
+          }
+          let word_string =
+            match data_helpers::ams_normalize_word_range(&word.range, &mut context, false) {
+              Ok(w) => w,
+              Err(_) => {
+                overflow_count += 1;
+                invalid_heading = true;
+                break 'sentences;
+              }
+            };
+          if !word_string.is_empty() {
+            sentence_buffer.push_str(&word_string);
+            sentence_buffer.push(' ');
+          }
+        }
+        if !sentence_buffer.is_empty() {
+          heading_buffer.push_str(&sentence_buffer);
+          heading_buffer.push(' ');
+        }
+      }
+      // If heading was valid and contains text, record it
+      if !invalid_heading && !heading_buffer.is_empty() {
+        // simplify/normalize to standard names
+        while heading_buffer.ends_with('\n') || heading_buffer.ends_with(' ') {
+          heading_buffer.pop();
+        }
+        heading_count += 1;
+        let this_heading_counter = thread_counts.entry(heading_buffer).or_insert(0);
+        *this_heading_counter += 1;
+      }
+    }
+    thread_counts.insert(String::from("heading_count"), heading_count);
+    thread_counts.insert(String::from("overflow_count"), overflow_count);
+    thread_counts
+  });
+
+  println!(
+    "{:?} Total traversed documents;",
+    catalog.remove("total_document_count").unwrap_or(0)
+  );
+  println!(
+    "{:?} headings;",
+    catalog.remove("heading_count").unwrap_or(0)
+  );
+  println!(
+    "{:?} discarded headings (long words)",
+    catalog.remove("overflow_count").unwrap_or(0)
+  );
+
+  let mut catalog_vec: Vec<(&String, &u64)> = catalog.iter().collect();
+  catalog_vec.sort_by(|a, b| b.1.cmp(a.1));
+
+  let heading_statistics_file = File::create(headings_report_filename)?;
+  let buffered_writer = BufWriter::with_capacity(BUFFER_CAPACITY, heading_statistics_file);
+  let mut csv_writer = csv::Writer::from_writer(buffered_writer);
+  for (heading, frequency) in catalog_vec {
+    csv_writer.serialize(HeadingRecord { heading, frequency })?;
+  }
+  csv_writer.flush()?;
+
+  let end = time::get_time();
+  let duration_sec = (end - start).num_milliseconds() / 1000;
+  println!("---");
+  println!("Headings statistics finished in {:?}s", duration_sec);
+
+  Ok(())
+}

--- a/examples/corpus_statement_paragraphs_model.rs
+++ b/examples/corpus_statement_paragraphs_model.rs
@@ -21,7 +21,7 @@ use libxml::xpath::Context;
 use llamapun::ams;
 use llamapun::ams::{AmsEnv, StructuralEnv};
 use llamapun::dnm::SpecialTagsOption;
-use llamapun::parallel_data::Corpus;
+use llamapun::parallel_data::*  ;
 use llamapun::util::data_helpers;
 
 use tar::{Builder, Header};
@@ -170,7 +170,7 @@ pub fn main() -> Result<(), Error> {
       }
       'sentences: for mut sentence in paragraph.iter() {
         sentence_buffer = String::new();
-        for word in sentence.simple_iter() {
+        for word in sentence.word_iter() {
           if !word.range.is_empty() {
             let word_string =
               match data_helpers::ams_normalize_word_range(&word.range, &mut context, discard_math)

--- a/examples/corpus_statement_paragraphs_model.rs
+++ b/examples/corpus_statement_paragraphs_model.rs
@@ -20,8 +20,8 @@ use crypto::sha2::Sha256;
 use libxml::xpath::Context;
 use llamapun::ams;
 use llamapun::ams::{AmsEnv, StructuralEnv};
-use llamapun::parallel_data::Corpus;
 use llamapun::dnm::SpecialTagsOption;
+use llamapun::parallel_data::Corpus;
 use llamapun::util::data_helpers;
 
 use tar::{Builder, Header};
@@ -75,8 +75,6 @@ impl TarBuilder {
   }
 }
 
-/// Given a `CorTeX` corpus of HTML5 documents, extract a token model as a
-/// single file
 pub fn main() -> Result<(), Error> {
   let start = SystemTime::now();
   let stamp = start.duration_since(UNIX_EPOCH).unwrap().as_secs();
@@ -175,7 +173,8 @@ pub fn main() -> Result<(), Error> {
         for word in sentence.simple_iter() {
           if !word.range.is_empty() {
             let word_string =
-              match data_helpers::ams_normalize_word_range(&word.range, &mut context, discard_math) {
+              match data_helpers::ams_normalize_word_range(&word.range, &mut context, discard_math)
+              {
                 Ok(w) => w,
                 Err(_) => {
                   overflow_count += 1;

--- a/examples/corpus_token_model.rs
+++ b/examples/corpus_token_model.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 use libxml::xpath::Context;
 use llamapun::dnm;
 use llamapun::dnm::SpecialTagsOption;
-use llamapun::parallel_data::Corpus;
+use llamapun::parallel_data::*;
 
 static BUFFER_CAPACITY: usize = 10_485_760;
 static MAX_WORD_LENGTH: usize = 25;
@@ -98,7 +98,7 @@ pub fn main() {
       for mut sentence in paragraph.iter() {
         let mut sentence_buffer = String::new();
         let mut invalid_sentence = true;
-        'words: for word in sentence.simple_iter() {
+        'words: for word in sentence.word_iter() {
           let lexeme_str: String;
           if !word.range.is_empty() {
             let word_string = word

--- a/src/dnm/mod.rs
+++ b/src/dnm/mod.rs
@@ -193,6 +193,11 @@ impl DNM {
     }
   }
 
+  /// Get the range representing the full DNM
+  pub fn get_range(&self) -> Result<DNMRange, ()> {
+    self.get_range_of_node(self.root_node)
+  }
+
   /// The heart of the dnm generation...
   fn recurse_node_create(&mut self, node: RoNode) {
     if node.is_text_node() {

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -1,424 +1,121 @@
 //! Data structures and Iterators for rayon-enabled parallel processing
 //! including parallel I/O in walking a corpus
 //! as well as DOM primitives that allow parallel iterators on XPath results, etc
-use jwalk::WalkDir as ParWalkDir;
-use rayon::iter::ParallelBridge;
-use rayon::iter::ParallelIterator;
-use std::collections::HashMap;
+use crate::dnm::{DNMParameters, DNMRange, DNM};
+use libxml::readonly::RoNode;
 use std::vec::IntoIter;
 
-use libxml::parser::{Parser, XmlParseError};
-use libxml::readonly::RoNode;
-use libxml::tree::Document as XmlDoc;
-use libxml::xpath::Context;
+/* ---- Containers ----- */
+/// container and API for a Corpus capable of parallel walks over its documents
+pub mod corpus;
+/// container and API for a Document yielded during a parallel corpus walk
+pub mod document;
+pub use self::corpus::Corpus;
+pub use self::document::Document;
 
-use crate::dnm::{DNMParameters, DNMRange, DNM};
-use crate::tokenizer::Tokenizer;
-
-/// A parallel iterable Corpus of HTML5 documents
-pub struct Corpus {
-  /// root directory
-  pub path: String,
-  /// document XHTML5 parser
-  pub xml_parser: Parser,
-  /// document HTML5 parser
-  pub html_parser: Parser,
-  /// `DNM`-aware sentence and word tokenizer
-  pub tokenizer: Tokenizer,
-  /// Default setting for `DNM` generation
-  pub dnm_parameters: DNMParameters,
-  /// Extension of corpus files (for specially tailored resources such as DLMF's .html5)
-  /// defaults to selecting .html AND .xhtml files
-  pub extension: Option<String>,
-}
-
-/// One of our math documents, thread-friendly
-pub struct Document<'d> {
-  /// The DOM of the document
-  pub dom: XmlDoc,
-  /// The file path of the document
-  pub path: String,
-  /// A reference to the corpus containing this document
-  pub corpus: &'d Corpus,
-  /// If it exists, the DNM corresponding to this document
-  pub dnm: Option<DNM>,
-}
-
-/// An iterator over headings of a `Document`. Ignores headings containing `ltx_ERROR` markup
-pub struct HeadingIterator<'iter> {
-  /// A walker over paragraph nodes
-  walker: IntoIter<RoNode>,
-  /// A reference to the document over which we iterate
-  pub document: &'iter Document<'iter>,
-}
-
-/// A heading of a document with a DNM
-pub struct Heading<'p> {
-  /// The dnm of this paragraph
+/// A DNM with associated document parent (e.g. for paragraphs, headings)
+pub struct ItemDNM<'p> {
+  /// The payload of the item
   pub dnm: DNM,
-  /// A reference to the document containing this paragraph
+  /// A reference to the parent document
   pub document: &'p Document<'p>,
 }
 
-/// An iterator over paragraphs of a `Document`. Ignores paragraphs containing `ltx_ERROR` markup
-pub struct ParagraphIterator<'iter> {
-  /// A walker over paragraph nodes
-  walker: IntoIter<RoNode>,
-  /// A reference to the document over which we iterate
-  pub document: &'iter Document<'iter>,
-}
-
-/// A paragraph of a document with a DNM
-pub struct Paragraph<'p> {
-  /// The dnm of this paragraph
-  pub dnm: DNM,
-  /// A reference to the document containing this paragraph
-  pub document: &'p Document<'p>,
-}
-
-/// An iterator over the sentences of a document/paragraph
-pub struct SentenceIterator<'iter> {
-  /// The walker over the sentence ranges
-  walker: IntoIter<DNMRange<'iter>>,
-  // pub paragraph : &'iter Paragraph<'iter>
-  /// A reference to the document we are working on
-  pub document: &'iter Document<'iter>,
-}
-
-/// A sentence in a document
-pub struct Sentence<'s> {
+/// A DNMRange with associated document
+pub struct ItemDNMRange<'s> {
   /// The range of the sentence
   pub range: DNMRange<'s>,
-  // pub paragraph : &'s Paragraph<'s>
   /// The document containing this sentence
   pub document: &'s Document<'s>,
 }
 
-/// An iterator over the words of a sentence, where the words are only defined
-/// by their ranges
-pub struct SimpleWordIterator<'iter> {
-  /// The walker over the words
+/* ---- Iterators ----- */
+
+/// Generic iterater over read-only xml nodes. It is the responsibility of the abstraction returning `NodeIterator`
+/// to specify the grouping principle for collecting the nodes
+pub struct RoNodeIterator<'iter> {
+  /// A walker over read-only nodes
+  walker: IntoIter<RoNode>,
+  /// A reference to the owner document
+  pub document: &'iter Document<'iter>,
+}
+
+/// A generic iterator over DNMRanges with their associated document (e.g. for sentences)
+pub struct DNMRangeIterator<'iter> {
+  /// The walker over the sentence ranges
   walker: IntoIter<DNMRange<'iter>>,
-  /// The sentence containing the words
-  pub sentence: &'iter Sentence<'iter>,
+  /// A reference to the document we are working on
+  pub document: &'iter Document<'iter>,
 }
 
-/// A word with a DNM range and a reference to its owner parent
-pub struct Word<'w> {
-  /// The range of the word
-  pub range: DNMRange<'w>, // &'w str, // should we use the DNMRange instead???
-  /// The sentence containing this word
-  pub sentence: &'w Sentence<'w>,
-}
-
-impl Default for Corpus {
-  fn default() -> Corpus {
-    Corpus {
-      extension: None,
-      path: ".".to_string(),
-      tokenizer: Tokenizer::default(),
-      xml_parser: Parser::default(),
-      html_parser: Parser::default_html(),
-      dnm_parameters: DNMParameters::llamapun_normalization(),
+impl<'iter> Iterator for RoNodeIterator<'iter> {
+  type Item = ItemDNM<'iter>;
+  fn next(&mut self) -> Option<ItemDNM<'iter>> {
+    match self.walker.next() {
+      None => None,
+      Some(node) => {
+        // Create a DNM for the current ItemDNM
+        let dnm = DNM::new(node, DNMParameters::llamapun_normalization());
+        Some(ItemDNM {
+          dnm,
+          document: self.document,
+        })
+      }
     }
   }
 }
 
-impl Corpus {
-  /// Create a new parallel-processing corpus with the base directory `dirpath`
-  pub fn new(dirpath: String) -> Self {
-    Corpus {
-      path: dirpath,
-      ..Corpus::default()
-    }
-  }
+/// An iterator adaptor for filtered selections over a document
+pub trait XPathFilteredIterator<'p> {
+  /// the sentences for the resulting selection
+  fn to_sentences(&'p self) -> Vec<DNMRange<'p>>;
+  /// the owner document being selected over
+  fn get_document(&'p self) -> &'p Document;
 
-  /// Get a parallel iterator over the documents
-  pub fn catalog_with_parallel_walk<F>(&self, closure: F) -> HashMap<String, u64>
-  where
-    F: Fn(Document) -> HashMap<String, u64> + Send + Sync,
-  {
-    ParWalkDir::new(self.path.clone())
-      .num_threads(rayon::current_num_threads())
-      .skip_hidden(true)
-      .sort(false)
-      .into_iter()
-      .filter_map(|each| {
-        if let Ok(entry) = each {
-          let file_name = entry.file_name.to_str().unwrap_or("");
-          let selected = if let Some(ref extension) = self.extension {
-            file_name.ends_with(extension)
-          } else {
-            file_name.ends_with(".html") || file_name.ends_with(".xhtml")
-          };
-          if selected {
-            let path = entry.path().to_str().unwrap_or("").to_owned();
-            if !path.is_empty() {
-              return Some(path);
-            }
-          }
-        }
-        // all other cases
-        None
-      })
-      .enumerate()
-      .par_bridge()
-      .map(|each| {
-        let (index, path) = each;
-        let document = Document::new(path, &self).unwrap();
-        if index % 1000 == 0 {
-          println!(
-            "-- catalog_with_parallel_walk processing document {:?}",
-            1 + index
-          );
-        }
-        closure(document)
-      })
-      .reduce(HashMap::new, |mut map1, map2| {
-        for (k, v) in map2 {
-          let entry = map1.entry(k).or_insert(0);
-          *entry += v;
-        }
-        map1
-      })
+  /// Get an iterator over the sentences in this paragraph
+  fn iter(&'p mut self) -> DNMRangeIterator<'p> {
+    DNMRangeIterator {
+      walker: self.to_sentences().into_iter(),
+      document: self.get_document(),
+    }
   }
 }
 
-impl<'d> Document<'d> {
-  /// Load a new document
-  pub fn new(filepath: String, corpus: &'d Corpus) -> Result<Self, XmlParseError> {
-    let dom = if filepath.ends_with(".xhtml") {
-      corpus.xml_parser.parse_file(&filepath)?
+impl<'p> XPathFilteredIterator<'p> for ItemDNM<'p> {
+  fn get_document(&'p self) -> &Document {
+    &self.document
+  }
+  fn to_sentences(&'p self) -> Vec<DNMRange<'p>> {
+    self.document.corpus.tokenizer.sentences(&self.dnm)
+  }
+}
+
+impl<'iter> Iterator for DNMRangeIterator<'iter> {
+  type Item = ItemDNMRange<'iter>;
+  fn next(&mut self) -> Option<ItemDNMRange<'iter>> {
+    if let Some(range) = self.walker.next() {
+      if range.is_empty() {
+        self.next()
+      } else {
+        Some(ItemDNMRange {
+          range,
+          document: &self.document,
+        })
+      }
     } else {
-      corpus.html_parser.parse_file(&filepath)?
-    };
-
-    Ok(Document {
-      path: filepath,
-      dom,
-      corpus,
-      dnm: None,
-    })
-  }
-
-  /// Obtain the problem-free logical headings of a libxml `Document`
-  pub fn get_heading_nodes(&self) -> Vec<RoNode> {
-    Document::heading_nodes(&self.dom)
-  }
-  /// Associated function for `get_paragraph_nodes`
-  fn heading_nodes(doc: &XmlDoc) -> Vec<RoNode> {
-    let xpath_context = Context::new(doc).unwrap();
-    match xpath_context.evaluate(
-      "//*[contains(@class,'ltx_title') and (local-name()='h2' or local-name()='h3' or local-name()='h4' or local-name()='h5' or local-name()='h6') and not(descendant::*[contains(@class,'ltx_ERROR')]) and not(preceding-sibling::*[contains(@class,'ltx_ERROR')])]",
-    ) {
-      Ok(found_payload) => found_payload.get_readonly_nodes_as_vec(),
-      _ => Vec::new(),
-    }
-  }
-  /// Get an iterator over the headings of the document
-  pub fn heading_iter(&self) -> HeadingIterator {
-    let headings = Document::heading_nodes(&self.dom);
-    HeadingIterator {
-      walker: headings.into_iter(),
-      document: self,
-    }
-  }
-
-  /// Obtain the problem-free logical paragraphs of a libxml `Document`
-  pub fn get_paragraph_nodes(&self) -> Vec<RoNode> {
-    Document::paragraph_nodes(&self.dom)
-  }
-
-  /// Associated function for `get_paragraph_nodes`
-  fn paragraph_nodes(doc: &XmlDoc) -> Vec<RoNode> {
-    let xpath_context = Context::new(doc).unwrap();
-    match xpath_context.evaluate(
-      "//*[local-name()='div' and contains(@class,'ltx_para') and not(descendant::*[contains(@class,'ltx_ERROR')]) and not(preceding-sibling::*[contains(@class,'ltx_ERROR')])]",
-    ) {
-      Ok(found_payload) => found_payload.get_readonly_nodes_as_vec(),
-      _ => Vec::new(),
-    }
-  }
-
-  /// Get an iterator over the paragraphs of the document
-  pub fn paragraph_iter(&self) -> ParagraphIterator {
-    let paras = Document::paragraph_nodes(&self.dom);
-    ParagraphIterator {
-      walker: paras.into_iter(),
-      document: self,
-    }
-  }
-
-  fn abstract_p_node(doc: &XmlDoc) -> Option<RoNode> {
-    let xpath_context = Context::new(doc).unwrap();
-    match xpath_context.evaluate(
-      "//*[local-name()='div' and contains(@class,'ltx_abstract') and not(descendant::*[contains(@class,'ltx_ERROR')])]/p[1]",
-    ) {
-      Ok(found_payload) => {
-        let mut abs = found_payload.get_readonly_nodes_as_vec();
-        if !abs.is_empty() {
-          Some(abs.remove(0))
-        } else {
-          None
-        }
-      },
-      _ => None,
-    }
-  }
-
-  /// Get an iterator over the paragraphs of the document, AND notable additional paragraphs, such as abstracts
-  pub fn extended_paragraph_iter(&self) -> ParagraphIterator {
-    let mut paras = Document::paragraph_nodes(&self.dom);
-    if let Some(anode) = Document::abstract_p_node(&self.dom) {
-      paras.push(anode);
-    }
-    ParagraphIterator {
-      walker: paras.into_iter(),
-      document: self,
-    }
-  }
-
-  /// Obtain the MathML <math> nodes of a libxml `Document`
-  pub fn get_math_nodes(&self) -> Vec<RoNode> {
-    Document::math_nodes(&self.dom)
-  }
-
-  /// Associated function for `get_math_nodes`
-  fn math_nodes(doc: &XmlDoc) -> Vec<RoNode> {
-    let xpath_context = Context::new(doc).unwrap();
-    match xpath_context.evaluate("//*[local-name()='math']") {
-      Ok(found_payload) => found_payload.get_readonly_nodes_as_vec(),
-      _ => Vec::new(),
-    }
-  }
-  /// Obtain the <span[class=ltx_ref]> nodes of a libxml `Document`
-  pub fn get_ref_nodes(&self) -> Vec<RoNode> {
-    Document::ref_nodes(&self.dom)
-  }
-  /// Associated function for `get_ref_nodes`
-  fn ref_nodes(doc: &XmlDoc) -> Vec<RoNode> {
-    let xpath_context = Context::new(doc).unwrap();
-    match xpath_context.evaluate("//*[(local-name()='span' or local-name()='a') and (contains(@class,'ltx_ref ') or @class='ltx_ref')]") {
-      Ok(found_payload) => found_payload.get_readonly_nodes_as_vec(),
-      _ => Vec::new(),
-    }
-  }
-
-  /// Get an iterator over the sentences of the document
-  pub fn sentence_iter(&mut self) -> SentenceIterator {
-    if self.dnm.is_none() {
-      if let Some(root) = self.dom.get_root_readonly() {
-        self.dnm = Some(DNM::new(root, self.corpus.dnm_parameters.clone()));
-      }
-    }
-    let tokenizer = &self.corpus.tokenizer;
-    let sentences = tokenizer.sentences(self.dnm.as_ref().unwrap());
-    SentenceIterator {
-      walker: sentences.into_iter(),
-      document: self,
+      None
     }
   }
 }
 
-impl<'iter> Iterator for HeadingIterator<'iter> {
-  type Item = Heading<'iter>;
-  fn next(&mut self) -> Option<Heading<'iter>> {
-    match self.walker.next() {
-      None => None,
-      Some(node) => {
-        // Create a DNM for the current Heading
-        let dnm = DNM::new(node, DNMParameters::llamapun_normalization());
-        Some(Heading {
-          dnm,
-          document: self.document,
-        })
-      }
-    }
-  }
-}
-
-impl<'p> Heading<'p> {
-  /// Get an iterator over the sentences in this paragraph
-  pub fn iter(&'p mut self) -> SentenceIterator<'p> {
-    let tokenizer = &self.document.corpus.tokenizer;
-    let sentences = tokenizer.sentences(&self.dnm);
-    SentenceIterator {
-      walker: sentences.into_iter(),
-      document: self.document,
-    }
-  }
-}
-
-impl<'iter> Iterator for ParagraphIterator<'iter> {
-  type Item = Paragraph<'iter>;
-  fn next(&mut self) -> Option<Paragraph<'iter>> {
-    match self.walker.next() {
-      None => None,
-      Some(node) => {
-        // Create a DNM for the current paragraph
-        let dnm = DNM::new(node, DNMParameters::llamapun_normalization());
-        Some(Paragraph {
-          dnm,
-          document: self.document,
-        })
-      }
-    }
-  }
-}
-
-impl<'p> Paragraph<'p> {
-  /// Get an iterator over the sentences in this paragraph
-  pub fn iter(&'p mut self) -> SentenceIterator<'p> {
-    let tokenizer = &self.document.corpus.tokenizer;
-    let sentences = tokenizer.sentences(&self.dnm);
-    SentenceIterator {
-      walker: sentences.into_iter(),
-      document: self.document,
-    }
-  }
-}
-
-impl<'iter> Iterator for SentenceIterator<'iter> {
-  type Item = Sentence<'iter>;
-  fn next(&mut self) -> Option<Sentence<'iter>> {
-    match self.walker.next() {
-      None => None,
-      Some(range) => {
-        if range.is_empty() {
-          self.next()
-        } else {
-          let sentence = Sentence {
-            range,
-            document: self.document,
-          };
-          Some(sentence)
-        }
-      }
-    }
-  }
-}
-
-impl<'s> Sentence<'s> {
+impl<'s> ItemDNMRange<'s> {
   /// Get an iterator over the words (using rudimentary heuristics)
-  pub fn simple_iter(&'s mut self) -> SimpleWordIterator<'s> {
+  pub fn word_iter(&'s mut self) -> DNMRangeIterator<'s> {
     let tokenizer = &self.document.corpus.tokenizer;
     let words = tokenizer.words(&self.range);
-    SimpleWordIterator {
+    DNMRangeIterator {
       walker: words.into_iter(),
-      sentence: self,
-    }
-  }
-}
-
-impl<'iter> Iterator for SimpleWordIterator<'iter> {
-  type Item = Word<'iter>;
-  fn next(&mut self) -> Option<Word<'iter>> {
-    match self.walker.next() {
-      None => None,
-      Some(range) => Some(Word {
-        range,
-        sentence: self.sentence,
-      }),
+      document: &self.document,
     }
   }
 }

--- a/src/parallel_data.rs
+++ b/src/parallel_data.rs
@@ -119,3 +119,18 @@ impl<'s> ItemDNMRange<'s> {
     }
   }
 }
+
+impl<'s> ItemDNM<'s> {
+  /// Get an iterator over the words (using rudimentary heuristics)
+  pub fn word_iter(&'s mut self) -> DNMRangeIterator<'s> {
+    let tokenizer = &self.document.corpus.tokenizer;
+    let words = match self.dnm.get_range() {
+      Ok(range) => tokenizer.words(&range),
+      _ => Vec::new(),
+    };
+    DNMRangeIterator {
+      walker: words.into_iter(),
+      document: &self.document,
+    }
+  }
+}

--- a/src/parallel_data/corpus.rs
+++ b/src/parallel_data/corpus.rs
@@ -1,0 +1,100 @@
+use jwalk::WalkDir as ParWalkDir;
+use rayon::iter::ParallelBridge;
+use rayon::iter::ParallelIterator;
+use std::collections::HashMap;
+
+use crate::dnm::DNMParameters;
+use crate::tokenizer::Tokenizer;
+use super::document::Document;
+
+use libxml::parser::Parser;
+
+/// A parallel iterable Corpus of HTML5 documents
+pub struct Corpus {
+  /// root directory
+  pub path: String,
+  /// document XHTML5 parser
+  pub xml_parser: Parser,
+  /// document HTML5 parser
+  pub html_parser: Parser,
+  /// `DNM`-aware sentence and word tokenizer
+  pub tokenizer: Tokenizer,
+  /// Default setting for `DNM` generation
+  pub dnm_parameters: DNMParameters,
+  /// Extension of corpus files (for specially tailored resources such as DLMF's .html5)
+  /// defaults to selecting .html AND .xhtml files
+  pub extension: Option<String>,
+}
+
+impl Default for Corpus {
+  fn default() -> Corpus {
+    Corpus {
+      extension: None,
+      path: ".".to_string(),
+      tokenizer: Tokenizer::default(),
+      xml_parser: Parser::default(),
+      html_parser: Parser::default_html(),
+      dnm_parameters: DNMParameters::llamapun_normalization(),
+    }
+  }
+}
+
+impl Corpus {
+  /// Create a new parallel-processing corpus with the base directory `dirpath`
+  pub fn new(dirpath: String) -> Self {
+    Corpus {
+      path: dirpath,
+      ..Corpus::default()
+    }
+  }
+
+    /// Get a parallel iterator over the documents
+  pub fn catalog_with_parallel_walk<F>(&self, closure: F) -> HashMap<String, u64>
+  where
+    F: Fn(Document) -> HashMap<String, u64> + Send + Sync,
+  {
+    ParWalkDir::new(self.path.clone())
+      .num_threads(rayon::current_num_threads())
+      .skip_hidden(true)
+      .sort(false)
+      .into_iter()
+      .filter_map(|each| {
+        if let Ok(entry) = each {
+          let file_name = entry.file_name.to_str().unwrap_or("");
+          let selected = if let Some(ref extension) = self.extension {
+            file_name.ends_with(extension)
+          } else {
+            file_name.ends_with(".html") || file_name.ends_with(".xhtml")
+          };
+          if selected {
+            let path = entry.path().to_str().unwrap_or("").to_owned();
+            if !path.is_empty() {
+              return Some(path);
+            }
+          }
+        }
+        // all other cases
+        None
+      })
+      .enumerate()
+      .par_bridge()
+      .map(|each| {
+        let (index, path) = each;
+        let document = Document::new(path, &self).unwrap();
+        if index % 1000 == 0 {
+          println!(
+            "-- catalog_with_parallel_walk processing document {:?}",
+            1 + index
+          );
+        }
+        closure(document)
+      })
+      .reduce(HashMap::new, |mut map1, map2| {
+        for (k, v) in map2 {
+          let entry = map1.entry(k).or_insert(0);
+          *entry += v;
+        }
+        map1
+      })
+  }
+}

--- a/src/parallel_data/document.rs
+++ b/src/parallel_data/document.rs
@@ -1,0 +1,154 @@
+use libxml::parser::XmlParseError;
+use libxml::readonly::RoNode;
+use libxml::tree::Document as XmlDoc;
+use libxml::xpath::Context;
+
+use super::corpus::Corpus;
+use super::{DNMRangeIterator, RoNodeIterator};
+use crate::dnm::DNM;
+
+/// One of our math documents, thread-friendly
+pub struct Document<'d> {
+  /// The DOM of the document
+  pub dom: XmlDoc,
+  /// The file path of the document
+  pub path: String,
+  /// A reference to the corpus containing this document
+  pub corpus: &'d Corpus,
+  /// If it exists, the DNM corresponding to this document
+  pub dnm: Option<DNM>,
+}
+
+impl<'d> Document<'d> {
+  /// Load a new document
+  pub fn new(filepath: String, corpus: &'d Corpus) -> Result<Self, XmlParseError> {
+    let dom = if filepath.ends_with(".xhtml") {
+      corpus.xml_parser.parse_file(&filepath)?
+    } else {
+      corpus.html_parser.parse_file(&filepath)?
+    };
+
+    Ok(Document {
+      path: filepath,
+      dom,
+      corpus,
+      dnm: None,
+    })
+  }
+
+  /// Obtain the problem-free logical headings of a libxml `Document`
+  pub fn get_heading_nodes(&self) -> Vec<RoNode> {
+    Document::heading_nodes(&self.dom)
+  }
+  /// Associated function for `get_paragraph_nodes`
+  fn heading_nodes(doc: &XmlDoc) -> Vec<RoNode> {
+    let xpath_context = Context::new(doc).unwrap();
+    match xpath_context.evaluate(
+      "//*[contains(@class,'ltx_title') and (local-name()='h2' or local-name()='h3' or local-name()='h4' or local-name()='h5' or local-name()='h6') and not(descendant::*[contains(@class,'ltx_ERROR')]) and not(preceding-sibling::*[contains(@class,'ltx_ERROR')])]",
+    ) {
+      Ok(found_payload) => found_payload.get_readonly_nodes_as_vec(),
+      _ => Vec::new(),
+    }
+  }
+  /// Get an iterator over the headings of the document
+  pub fn heading_iter(&self) -> RoNodeIterator {
+    RoNodeIterator {
+      walker: Document::heading_nodes(&self.dom).into_iter(),
+      document: self,
+    }
+  }
+
+  /// Obtain the problem-free logical paragraphs of a libxml `Document`
+  pub fn get_paragraph_nodes(&self) -> Vec<RoNode> {
+    Document::paragraph_nodes(&self.dom)
+  }
+
+  /// Associated function for `get_paragraph_nodes`
+  fn paragraph_nodes(doc: &XmlDoc) -> Vec<RoNode> {
+    let xpath_context = Context::new(doc).unwrap();
+    match xpath_context.evaluate(
+      "//*[local-name()='div' and contains(@class,'ltx_para') and not(descendant::*[contains(@class,'ltx_ERROR')]) and not(preceding-sibling::*[contains(@class,'ltx_ERROR')])]",
+    ) {
+      Ok(found_payload) => found_payload.get_readonly_nodes_as_vec(),
+      _ => Vec::new(),
+    }
+  }
+
+  /// Get an iterator over the paragraphs of the document
+  pub fn paragraph_iter(&self) -> RoNodeIterator {
+    RoNodeIterator {
+      walker: Document::paragraph_nodes(&self.dom).into_iter(),
+      document: self,
+    }
+  }
+
+  fn abstract_p_node(doc: &XmlDoc) -> Option<RoNode> {
+    let xpath_context = Context::new(doc).unwrap();
+    match xpath_context.evaluate(
+      "//*[local-name()='div' and contains(@class,'ltx_abstract') and not(descendant::*[contains(@class,'ltx_ERROR')])]/p[1]",
+    ) {
+      Ok(found_payload) => {
+        let mut abs = found_payload.get_readonly_nodes_as_vec();
+        if !abs.is_empty() {
+          Some(abs.remove(0))
+        } else {
+          None
+        }
+      },
+      _ => None,
+    }
+  }
+
+  /// Get an iterator over the paragraphs of the document, AND notable additional paragraphs, such as abstracts
+  pub fn extended_paragraph_iter(&self) -> RoNodeIterator {
+    let mut paras = Document::paragraph_nodes(&self.dom);
+    if let Some(anode) = Document::abstract_p_node(&self.dom) {
+      paras.push(anode);
+    }
+    RoNodeIterator {
+      walker: paras.into_iter(),
+      document: self,
+    }
+  }
+
+  /// Obtain the MathML <math> nodes of a libxml `Document`
+  pub fn get_math_nodes(&self) -> Vec<RoNode> {
+    Document::math_nodes(&self.dom)
+  }
+
+  /// Associated function for `get_math_nodes`
+  fn math_nodes(doc: &XmlDoc) -> Vec<RoNode> {
+    let xpath_context = Context::new(doc).unwrap();
+    match xpath_context.evaluate("//*[local-name()='math']") {
+      Ok(found_payload) => found_payload.get_readonly_nodes_as_vec(),
+      _ => Vec::new(),
+    }
+  }
+  /// Obtain the <span[class=ltx_ref]> nodes of a libxml `Document`
+  pub fn get_ref_nodes(&self) -> Vec<RoNode> {
+    Document::ref_nodes(&self.dom)
+  }
+  /// Associated function for `get_ref_nodes`
+  fn ref_nodes(doc: &XmlDoc) -> Vec<RoNode> {
+    let xpath_context = Context::new(doc).unwrap();
+    match xpath_context.evaluate("//*[(local-name()='span' or local-name()='a') and (contains(@class,'ltx_ref ') or @class='ltx_ref')]") {
+      Ok(found_payload) => found_payload.get_readonly_nodes_as_vec(),
+      _ => Vec::new(),
+    }
+  }
+
+  /// Get an iterator over the sentences of the document
+  pub fn sentence_iter(&mut self) -> DNMRangeIterator {
+    if self.dnm.is_none() {
+      if let Some(root) = self.dom.get_root_readonly() {
+        self.dnm = Some(DNM::new(root, self.corpus.dnm_parameters.clone()));
+      }
+    }
+    let tokenizer = &self.corpus.tokenizer;
+    let sentences = tokenizer.sentences(self.dnm.as_ref().unwrap());
+    DNMRangeIterator {
+      walker: sentences.into_iter(),
+      document: self,
+    }
+  }
+}

--- a/src/patterns/rules.rs
+++ b/src/patterns/rules.rs
@@ -782,10 +782,10 @@ fn load_rule<PatternT, RuleT>(
       summary: String::new(),
     });
   }
-  if rule_opt.is_none() {
-    Err(format!("{} \"{}\" has no content node", rule_type, &name))
+  if let Some(rule) = rule_opt {
+    Ok(rule_gen(rule, meta_opt.unwrap()))
   } else {
-    Ok(rule_gen(rule_opt.unwrap(), meta_opt.unwrap()))
+    Err(format!("{} \"{}\" has no content node", rule_type, &name))
   }
 }
 

--- a/tests/parallel_test.rs
+++ b/tests/parallel_test.rs
@@ -1,4 +1,4 @@
-use llamapun::parallel_data::Corpus;
+use llamapun::parallel_data::*;
 use std::collections::HashMap;
 
 #[test]
@@ -10,7 +10,7 @@ fn can_iterate_corpus() {
     let mut word_count = 0;
     for mut paragraph in document.paragraph_iter() {
       for mut sentence in paragraph.iter() {
-        for word in sentence.simple_iter() {
+        for word in sentence.word_iter() {
           word_count += 1;
           assert!(!word.range.is_empty());
         }


### PR DESCRIPTION
Working on some simplification here, as it is high time to make the API cleaner. The use case is having three different iterators over a `parallel_data::Document` - `paragraph_iter`, `extended_paragraph_iter`, and now `heading_iter`.

There is a lot of boilerplate code that needs to be tucked in:
 * I'm moving away from concrete types with identical struct signatures (e.g. `Paragraph` and `Heading` would be identical), for generic alternatives (`ItemDNM` and `ItemDNMRange`).
 * Splitting out the containers into individual submodules, and keeping the main `parallel_data` module small.
 * The last bit I will add is to make instantiating new iterators over a Document simpler, so that you could say:

```rust
let xpath_iterator = document.xpath_selector_iter(xpath_str);
let custom_iterator = document.custom_iter(filter_closure);
```

So that anyone could write small scripts with their own selectors, while staying within the parallel walk, and without having to extend the core modules directly. A `heading_iter` is still sensible, but `closed_set_headings_before_figures_iter` would be borderline absurd -- those custom types should reside outside of the core primitives. Similarly, `extended_paragraph_iter` needs a more transparent rename.